### PR TITLE
AI-567: Small enhancements to README

### DIFF
--- a/sam-sql-database/README.md
+++ b/sam-sql-database/README.md
@@ -100,13 +100,16 @@ The SQL Database agent supports importing CSV files to initialize or populate yo
 You can directly edit your agent's YAML configuration file:
 
 ```yaml
-component_config:
   # Other configuration...
-  csv_files:
-    - /path/to/file1.csv
-    - /path/to/file2.csv
-  csv_directories:
-    - /path/to/csv/directory
+  - component_name: action_request_processor
+    # Other configuration...
+    component_config:
+      # Other configuration...
+      csv_files:
+        - /path/to/file1.csv
+        - /path/to/file2.csv
+      csv_directories:
+        - /path/to/csv/directory
 ```
 
 ### CSV File Format Requirements


### PR DESCRIPTION
The README.md for sam-sql-plugin didn't clearly say where the csv_files and csv_directories configs should be in the config file. This has been improved