### PR TITLE
PATCH: Add always_open configuration option to agents

### DIFF
--- a/sam-mongodb/src/agents/mongodb/mongodb_agent_component.py
+++ b/sam-mongodb/src/agents/mongodb/mongodb_agent_component.py
@@ -19,6 +19,13 @@ info.update(
         "description": "MongoDB agent for executing queries based on natural language prompts",
         "config_parameters": [
             {
+                "name": "always_open",
+                "required": False,
+                "description": "Whether this agent should always be open",
+                "type": "boolean",
+                "default": False
+            },
+            {
                 "name": "database_host",
                 "required": True,
                 "description": "MongoDB host",
@@ -98,7 +105,6 @@ info.update(
 class MongoDBAgentComponent(BaseAgentComponent):
     """Component for handling MongoDB database operations."""
 
-    info = info
     actions = [SearchQuery]
 
     def __init__(self, module_info: Dict[str, Any] = None, **kwargs):
@@ -114,6 +120,8 @@ class MongoDBAgentComponent(BaseAgentComponent):
         module_info = module_info or info
 
         super().__init__(module_info, **kwargs)
+        self.info = copy.deepcopy(module_info)
+        self.info["always_open"] = self.get_config("always_open", False)
 
         self.agent_name = self.get_config("agent_name")
         self.database_purpose = self.get_config("database_purpose")

--- a/solace-event-mesh/src/agents/solace_event_mesh/solace_event_mesh_agent_component.py
+++ b/solace-event-mesh/src/agents/solace_event_mesh/solace_event_mesh_agent_component.py
@@ -35,6 +35,13 @@ info.update(
                 "default": "Event Mesh agent for publishing requests to and receiving responses from the Solace event mesh",
             },
             {
+                "name": "always_open",
+                "required": False,
+                "description": "Whether this agent should always be open",
+                "type": "boolean",
+                "default": False
+            },
+            {
                 "name": "actions",
                 "required": True,
                 "description": "List of actions this agent can perform",
@@ -137,6 +144,7 @@ class SolaceEventMeshAgentComponent(BaseAgentComponent):
 
         self.agent_description = self.get_config("agent_description")
         module_info["agent_name"] = self.agent_name
+        self.info["always_open"] = self.get_config("always_open", False)
 
         # Create action instances from configuration
         actions_config = self.get_config("actions", [])


### PR DESCRIPTION
## What is the purpose of this change?

The purpose of this change is to introduce the `always_open` configuration parameter to agents, which allows these components to be designated as always open. This enhances flexibility in agent configuration and operation, streamlining processes that require constant availability and interaction.

## How is this accomplished?

- Added `always_open` config to agents.

## Anything reviews should focus on/be aware of?

Make sure to verify the proper functioning of the new `always_open` parameter and its integration with existing workflows.