### PR TITLE
Fixed bugs with importing CSV files and header formatting

### DIFF
--- a/sam-sql-database/src/agents/sql_database/services/csv_import_service.py
+++ b/sam-sql-database/src/agents/sql_database/services/csv_import_service.py
@@ -56,6 +56,35 @@ class CsvImportService:
             except Exception as e:
                 log.error("Error importing CSV file %s: %s", csv_file, str(e))
 
+
+    @staticmethod
+    def convert_headers_to_snake_case(headers: List[str]) -> List[str]:
+        """Convert a list of headers to snake_case.
+
+        Args:
+            headers: List of header strings
+
+        Returns:
+            List of converted header strings
+        """
+        converted_headers = []
+
+        for header in headers:
+            header = header.strip().replace(' ', '_')  # replace spaces with underscores
+            new_header = ""
+            if "_" in header:  # assume it is already in snake_case
+                new_header += header.lower()
+            else:  # do reformat to snake_case
+                for c in header:
+                    if c.isupper():
+                        new_header += "_" + c.lower()
+                    else:
+                        new_header += c
+                new_header = new_header.lstrip('_')
+            converted_headers.append(new_header)
+
+        return converted_headers
+
     def _import_csv_file(self, file_path: str) -> None:
         """Import a single CSV file into a database table.
         
@@ -75,13 +104,11 @@ class CsvImportService:
         try:
             # Read CSV headers and first row
             with open(file_path, 'r', encoding='utf-8') as f:
-                reader = csv.reader(f)
+                reader = csv.reader(f, skipinitialspace=True) # remove spaces after commas
                 headers = next(reader)
                 
                 # Convert headers to snake_case
-                headers = [''.join(['_' + c.lower() if c.isupper() else c 
-                                  for c in header]).lstrip('_') 
-                         for header in headers]
+                headers = self.convert_headers_to_snake_case(headers)
 
                 # Create table
                 columns = []


### PR DESCRIPTION
This PR fixes issues when importing CSV files that contain spaces after commas and improves header parsing for cases where headers:
- Have leading/trailing spaces
- Use CamelCase
- Contain underscores
- Contain spaces between words

## Problem
Before, when importing a CSV file like this:
```csv
nospace, single space, Capital, under_score, Capital_Underscore, DataColumn
1, 2, 3, 4, 5, 6
1, 2, 3, 4, 5, 6
1, 2, 3, 4, 5, 6
```
using: 
```python
reader = csv.reader(f)
```
The headers were read with leading spaces, and the existing snake_case conversion logic didn’t handle them properly. It relied on lstrip('_'), which only removed underscores and didn’t handle actual spaces.
It also had issues where:
- Columns already containing underscores would end up with multiple consecutive underscores
- Headers in CamelCase or with spaces were not normalized properly

Result with old code:
```python
['nospace', ' single space', ' Capital', ' under_score', ' Capital_Underscore', ' DataColumn']
→ becomes →
['nospace', ' single space', ' _capital', ' under_score', ' _capital__underscore', ' _data_column']
```
These inconsistencies caused problems when mapping to SQL columns — eventually crashing, or failing to create the table altogether.

## Fix
- Added `skipinitialspace=True` to `csv.reader()` to strip spaces after commas automatically.
- Replaced the inline snake_case logic with a proper utility function: `convert_headers_to_snake_case()` which handles all the cases properly

Result with new code:
```python
['nospace', ' single space', ' Capital', ' under_score', ' Capital_Underscore', ' DataColumn']
→ becomes →
['nospace', 'single_space', 'capital', 'under_score', 'capital_underscore', 'data_column']
```