### PR TITLE
AI-762: Limit the total size of inline files

### DIFF
--- a/sam-sql-database/src/agents/sql_database/actions/search_query.py
+++ b/sam-sql-database/src/agents/sql_database/actions/search_query.py
@@ -19,7 +19,7 @@ from solace_agent_mesh.common.action_response import (
     InlineFile,
 )
 
-MAX_INLINE_FILE_SIZE = 100000  # 100KB
+MAX_TOTAL_INLINE_FILE_SIZE = 100000  # 100KB
 
 
 class SearchQuery(Action):
@@ -274,6 +274,7 @@ Ensure that all SQL queries are compatible with {db_type}.
         # Create files for each successful query
         files = []
         inline_files = []
+        total_size = 0
 
         for i, (purpose, sql_query, results) in enumerate(query_results, 1):
             updated_results = self._stringify_non_standard_objects(results)
@@ -297,7 +298,11 @@ Ensure that all SQL queries are compatible with {db_type}.
                 f"query_{i}_results_{random.randint(100000, 999999)}.{file_extension}"
             )
 
-            if inline_result and len(content) < MAX_INLINE_FILE_SIZE:
+            total_size += len(content)
+            if total_size > MAX_TOTAL_INLINE_FILE_SIZE:
+                inline_result = False
+
+            if inline_result:
                 inline_files.append(InlineFile(content, file_name))
             else:
                 data_source = f"SQL Agent - Search Query {i} - {purpose}"

--- a/sam-sql-database/src/agents/sql_database/actions/search_query.py
+++ b/sam-sql-database/src/agents/sql_database/actions/search_query.py
@@ -13,7 +13,13 @@ from collections.abc import Mapping
 
 from solace_agent_mesh.common.action import Action
 from solace_agent_mesh.services.file_service import FileService
-from solace_agent_mesh.common.action_response import ActionResponse, ErrorInfo, InlineFile
+from solace_agent_mesh.common.action_response import (
+    ActionResponse,
+    ErrorInfo,
+    InlineFile,
+)
+
+MAX_INLINE_FILE_SIZE = 100000  # 100KB
 
 
 class SearchQuery(Action):
@@ -51,20 +57,22 @@ class SearchQuery(Action):
                         "type": "boolean",
                         "required": False,
                         "default": True,
-                    }
+                    },
                 ],
                 "required_scopes": ["<agent_name>:search_query:execute"],
             },
-            **kwargs
+            **kwargs,
         )
 
-    def invoke(self, params: Dict[str, Any], meta: Dict[str, Any] = None) -> ActionResponse:
+    def invoke(
+        self, params: Dict[str, Any], meta: Dict[str, Any] = None
+    ) -> ActionResponse:
         """Execute the search query based on the natural language prompt.
-        
+
         Args:
             params: Action parameters including the natural language query and response format
             meta: Optional metadata
-            
+
         Returns:
             ActionResponse containing the query results
         """
@@ -75,29 +83,35 @@ class SearchQuery(Action):
 
             response_format = params.get("response_format", "yaml").lower()
             if response_format not in ["yaml", "markdown", "json", "csv"]:
-                raise ValueError("Invalid response format. Choose 'yaml', 'markdown', 'json', or 'csv'")
+                raise ValueError(
+                    "Invalid response format. Choose 'yaml', 'markdown', 'json', or 'csv'"
+                )
 
             # Get the SQL queries from the natural language query
             sql_queries = self._generate_sql_queries(query)
-            
+
             # Execute each query and collect results
             db_handler = self.get_agent().get_db_handler()
             query_results = []
             failed_queries = []
-            
+
             for purpose, sql_query in sql_queries:
                 try:
                     results = db_handler.execute_query(sql_query)
                     query_results.append((purpose, sql_query, results))
                 except Exception as e:
                     failed_queries.append((purpose, sql_query, str(e)))
-            
+
+            inline_result = params.get("inline_result", True)
+            if isinstance(inline_result, str):
+                inline_result = inline_result.lower() == "true"
+
             # Create response with files for each successful query
             return self._create_multi_query_response(
                 query_results=query_results,
                 failed_queries=failed_queries,
                 response_format=response_format,
-                inline_result=params.get("inline_result", True),
+                inline_result=inline_result,
                 meta=meta,
                 query={"query": query},
             )
@@ -105,18 +119,20 @@ class SearchQuery(Action):
         except Exception as e:
             return ActionResponse(
                 message=f"Error executing search query: {str(e)}",
-                error_info=ErrorInfo(str(e))
+                error_info=ErrorInfo(str(e)),
             )
 
-    def _generate_sql_queries(self, natural_language_query: str) -> List[Tuple[str, str]]:
+    def _generate_sql_queries(
+        self, natural_language_query: str
+    ) -> List[Tuple[str, str]]:
         """Generate SQL queries from natural language prompt.
-        
+
         Args:
             natural_language_query: Natural language description of the query
-            
+
         Returns:
             List of tuples containing (query_purpose, sql_query)
-            
+
         Raises:
             ValueError: If query generation fails
         """
@@ -177,15 +193,15 @@ Ensure that all SQL queries are compatible with {db_type}.
 
             sql_queries = self._get_all_tags(content, "sql_query")
             purposes = self._get_all_tags(content, "query_purpose")
-            
+
             if not sql_queries:
                 raise ValueError("Failed to generate SQL query")
-                
+
             # Match purposes with queries
             if len(purposes) != len(sql_queries):
                 # If counts don't match, use generic purposes
                 purposes = [f"Query {i+1}" for i in range(len(sql_queries))]
-                
+
             return list(zip(purposes, sql_queries))
 
         except Exception as e:
@@ -193,11 +209,11 @@ Ensure that all SQL queries are compatible with {db_type}.
 
     def _get_all_tags(self, result_text: str, tag_name: str) -> list:
         """Extract content from XML-like tags in the text.
-        
+
         Args:
             result_text: Text to search for tags
             tag_name: Name of the tag to find
-            
+
         Returns:
             List of strings containing the content of each matching tag
         """
@@ -214,7 +230,7 @@ Ensure that all SQL queries are compatible with {db_type}.
         query: Dict[str, Any],
     ) -> ActionResponse:
         """Create a response with multiple query results as files.
-        
+
         Args:
             query_results: List of tuples (purpose, sql_query, results)
             failed_queries: List of tuples (purpose, sql_query, error_message)
@@ -222,40 +238,46 @@ Ensure that all SQL queries are compatible with {db_type}.
             inline_result: Whether to return inline files
             meta: Metadata including session_id
             query: Original query for file metadata
-            
+
         Returns:
             ActionResponse with files or inline files for each query result
         """
         file_service = FileService()
         session_id = meta.get("session_id")
-        
+
         # Build message with query summary
         message_parts = []
-        
+
         if not query_results and not failed_queries:
             return ActionResponse(
                 message="No SQL queries were generated from your request. Please try again with a more specific query.",
             )
-        
+
         # Add summary of successful queries
         if query_results:
-            message_parts.append(f"Successfully executed {len(query_results)} SQL queries:")
+            message_parts.append(
+                f"Successfully executed {len(query_results)} SQL queries:"
+            )
             for i, (purpose, sql_query, _) in enumerate(query_results, 1):
                 message_parts.append(f"\n{i}. {purpose}\nSQL: ```{sql_query}```")
-        
+
         # Add summary of failed queries
         if failed_queries:
-            message_parts.append(f"\n\nFailed to execute {len(failed_queries)} SQL queries:")
+            message_parts.append(
+                f"\n\nFailed to execute {len(failed_queries)} SQL queries:"
+            )
             for i, (purpose, sql_query, error) in enumerate(failed_queries, 1):
-                message_parts.append(f"\n{i}. {purpose}\nSQL: ```{sql_query}```\nError: {error}")
-        
+                message_parts.append(
+                    f"\n{i}. {purpose}\nSQL: ```{sql_query}```\nError: {error}"
+                )
+
         # Create files for each successful query
         files = []
         inline_files = []
-        
+
         for i, (purpose, sql_query, results) in enumerate(query_results, 1):
             updated_results = self._stringify_non_standard_objects(results)
-            
+
             # Format the results based on the requested format
             if response_format == "yaml":
                 content = yaml.dump(updated_results)
@@ -269,11 +291,13 @@ Ensure that all SQL queries are compatible with {db_type}.
             else:  # CSV
                 content = self._format_csv(updated_results)
                 file_extension = "csv"
-            
+
             # Create a unique filename for each query
-            file_name = f"query_{i}_results_{random.randint(100000, 999999)}.{file_extension}"
-            
-            if inline_result:
+            file_name = (
+                f"query_{i}_results_{random.randint(100000, 999999)}.{file_extension}"
+            )
+
+            if inline_result and len(content) < MAX_INLINE_FILE_SIZE:
                 inline_files.append(InlineFile(content, file_name))
             else:
                 data_source = f"SQL Agent - Search Query {i} - {purpose}"
@@ -281,14 +305,18 @@ Ensure that all SQL queries are compatible with {db_type}.
                     content.encode(), file_name, session_id, data_source=data_source
                 )
                 files.append(file_meta)
-        
+
         # Add file summary to message
         if query_results:
-            if inline_result:
-                message_parts.append(f"\n\nResults are available in {len(query_results)} attached inline {response_format.upper()} files.")
-            else:
-                message_parts.append(f"\n\nResults are available in {len(query_results)} attached {response_format.upper()} files.")
-        
+            if inline_files:
+                message_parts.append(
+                    f"\n\nResults are available in {len(inline_files)} attached inline {response_format.upper()} files."
+                )
+            if files:
+                message_parts.append(
+                    f"\n\nResults are {'also ' if len(inline_files) > 0 else ''} available in {len(files)} attached {response_format.upper()} files."
+                )
+
         return ActionResponse(
             message="\n".join(message_parts),
             files=files if files else None,
@@ -310,7 +338,11 @@ Ensure that all SQL queries are compatible with {db_type}.
         markdown += "| " + " | ".join(["---" for _ in headers]) + " |\n"
 
         for row in results:
-            markdown += "| " + " | ".join(str(row.get(header, "")) for header in headers) + " |\n"
+            markdown += (
+                "| "
+                + " | ".join(str(row.get(header, "")) for header in headers)
+                + " |\n"
+            )
 
         return markdown
 
@@ -346,15 +378,16 @@ Ensure that all SQL queries are compatible with {db_type}.
 
     def _convert_iso_dates_to_datetime(self, query_json):
         """
-        Converts any occurrences of {"$date": "ISODateString"} in the JSON query to 
+        Converts any occurrences of {"$date": "ISODateString"} in the JSON query to
         datetime.datetime objects.
-        
+
         Args:
             query_json (dict or list): The JSON query to process.
-        
+
         Returns:
             dict or list: The input query with ISODate strings converted to datetime objects.
         """
+
         def convert(obj):
             if isinstance(obj, dict):
                 # If the object is a dictionary, iterate over the key-value pairs
@@ -370,6 +403,6 @@ Ensure that all SQL queries are compatible with {db_type}.
                 for i in range(len(obj)):
                     obj[i] = convert(obj[i])
             return obj
-        
+
         query = query_json.copy()
         return convert(query)


### PR DESCRIPTION
Two fixes:

1. The inline_file parameter comes in as a string, so if it is False, it still would eval to true
2. Count the total size of the response from the DB. If greater than 100K, send everything as references
