### PR TITLE
AI-792: Added Amazon Bedrock Agents File Attachment Support

### DIFF
--- a/sam-bedrock-agent/README.md
+++ b/sam-bedrock-agent/README.md
@@ -61,6 +61,7 @@ flows:
               param_description: "Input to send to the action." # [Optional] Description of the parameter to be pass to the action, 
               bedrock_agent_id: "FAKE_AGENT_ID" # The ID of the Amazon bedrock agent
               bedrock_agent_alias_id: "FAKE_AGENT_ALIAS_ID" # The alias ID of the Amazon bedrock agent
+              allow_files: false # Whether to allow uploading file to the agent. Limit: 5 files (10MB total size) - Supported formats: .pdf, .txt, .doc, .csv, .xls, .xlsx
               # required_scope: "<agent_name>:my_request_action:write" # Optional scope override
             # --- Add more agents ---
 

--- a/sam-bedrock-agent/configs/agents/bedrock_agent.yaml
+++ b/sam-bedrock-agent/configs/agents/bedrock_agent.yaml
@@ -73,6 +73,7 @@ flows:
               param_description: "Input to send to the action." # [Optional] Description of the parameter to be pass to the action, 
               bedrock_agent_id: "FAKE_AGENT_ID" # The ID of the Amazon bedrock agent
               bedrock_agent_alias_id: "FAKE_AGENT_ALIAS_ID" # The alias ID of the Amazon bedrock agent
+              allow_files: false # Whether to allow uploading file to the agent. Limit: 5 files (10MB total size) - Supported formats: .pdf, .txt, .doc, .csv, .xls, .xlsx
 
           bedrock_flows: # Optional, but at least one bedrock_agent or bedrock_flow must be provided
             # EXAMPLE of a bedrock flow, Add as many needed

--- a/sam-bedrock-agent/src/agents/bedrock_agent/actions/invoke_agent.py
+++ b/sam-bedrock-agent/src/agents/bedrock_agent/actions/invoke_agent.py
@@ -50,7 +50,7 @@ class InvokeAgent(Action):
             params.append(
                 {
                     "name": "files",
-                    "desc": f"[Optional] Files to append to the prompt. Only {FS_PROTOCOL} URLs. Max 5 files, 10MB total. Supported types: {SUPPORTED_FILE_TYPES}",
+                    "desc": f"[Optional] Files to append to the prompt. Only {FS_PROTOCOL} URLs. Max 5 files, 10MB total. Supported types: {SUPPORTED_FILE_TYPES}. Example of passing in files: ['{FS_PROTOCOL}://file1.pdf', '{FS_PROTOCOL}://file2.doc']",
                     "type": "array of strings",
                     "required": False
                 }

--- a/sam-bedrock-agent/src/agents/bedrock_agent/actions/invoke_agent.py
+++ b/sam-bedrock-agent/src/agents/bedrock_agent/actions/invoke_agent.py
@@ -120,7 +120,13 @@ class InvokeAgent(Action):
                     )
 
                 try:
-                    _, buffer, meta = file_service.resolve_url(url, session_id, return_extra=True)
+                    buffer, _, meta = file_service.resolve_url(url, session_id, return_extra=True)
+                    media_type = meta.get("mime_type")
+
+                    if isinstance(buffer, str):
+                        buffer = buffer.encode('utf-8')
+                        media_type = "text/plain"
+                        
                 except Exception as e:
                     log.error("Error resolving file URL: %s", e)
                     return ActionResponse(
@@ -141,7 +147,7 @@ class InvokeAgent(Action):
                     'source': {
                         'byteContent': {
                             'data': byte_content,
-                            'mediaType': meta.get("mime_type"),
+                            'mediaType': media_type,
                         },
                         'sourceType': 'BYTE_CONTENT'
                     },

--- a/sam-bedrock-agent/src/agents/bedrock_agent/actions/invoke_agent.py
+++ b/sam-bedrock-agent/src/agents/bedrock_agent/actions/invoke_agent.py
@@ -3,9 +3,26 @@
 from solace_ai_connector.common.log import log
 from typing import Dict, Any
 from botocore.exceptions import ClientError
+import base64
+import json
 
+from solace_agent_mesh.services.file_service import FileService, FS_PROTOCOL
+from solace_agent_mesh.services.file_service.file_utils import starts_with_fs_url
 from solace_agent_mesh.common.action import Action
 from solace_agent_mesh.common.action_response import ActionResponse, ErrorInfo
+
+# Limit: 5 files (10MB total size)
+# Format: .pdf, .txt, .doc, .csv, .xls, .xlsx
+MAX_FILE_LENGTH = 10485760  # 10MB
+MAX_NUM_FILES = 5
+SUPPORTED_FILE_TYPES = [
+    ".pdf",
+    ".txt",
+    ".doc",
+    ".csv",
+    ".xls",
+    ".xlsx",
+]
 
 class InvokeAgent(Action):
     """Invoke an Amazon Bedrock agent action."""
@@ -20,17 +37,29 @@ class InvokeAgent(Action):
         Raises:
             ValueError: If the action configuration is invalid or missing required parameters.
         """
-        super().__init__({
-            "name": action_config["name"],
-            "prompt_directive": action_config["description"],
-            "params": [
+        self.allow_files = action_config.get("allow_files", False)
+        params = [
                 {
                     "name": "input",
                     "desc": action_config.get("param_description", "Input to send to the action."),
                     "type": "string",
                     "required": True
                 }
-            ],
+            ]
+        if self.allow_files:
+            params.append(
+                {
+                    "name": "files",
+                    "desc": f"[Optional] Files to append to the prompt. Only {FS_PROTOCOL} URLs. Max 5 files, 10MB total. Supported types: {SUPPORTED_FILE_TYPES}",
+                    "type": "array of strings",
+                    "required": False
+                }
+            )
+        
+        super().__init__({
+            "name": action_config["name"],
+            "prompt_directive": action_config["description"],
+            "params": params,
             "required_scopes": [action_config.get("required_scope", f"<agent_name>:{action_config['name']}:execute")],
         },
         **kwargs,
@@ -44,16 +73,93 @@ class InvokeAgent(Action):
         if not self.bedrock_agent_id or not self.bedrock_agent_alias_id:
             raise ValueError("Missing required configuration for Bedrock agent ID or alias ID.")
         
+        
     def invoke(self, params, meta={}) -> ActionResponse:
         user_input = params.get("input")
+        files = params.get("files")
         session_id = meta.get("session_id")
+
+        session_state = None
+        if self.allow_files and files:
+            file_service = FileService()
+
+            if isinstance(files, str):
+                try:
+                    files = json.loads(files)
+                except json.JSONDecodeError:
+                    return ActionResponse(
+                        message="Invalid JSON format for files parameter.",
+                        error_info=ErrorInfo("Invalid JSON format for files parameter")
+                    )
+
+            if not isinstance(files, list):
+                return ActionResponse(
+                    message="Files parameter must be a list of file URLs.",
+                    error_info=ErrorInfo("Invalid files parameter")
+                )
+            if len(files) > MAX_NUM_FILES:
+                return ActionResponse(
+                    message=f"Too many files. Maximum is {MAX_NUM_FILES}.",
+                    error_info=ErrorInfo(f"Too many files. Maximum is {MAX_NUM_FILES}.")
+                )
+            for file in files:
+                if not starts_with_fs_url(file):
+                    return ActionResponse(
+                        message=f"Invalid file URL: {file}",
+                        error_info=ErrorInfo(f"Invalid file URL: {file}")
+                    )
+                
+            byte_contents = []
+            total_size = 0
+            for url in files:
+                file_name, _ = file_service.get_parsed_url(url)
+                if not file_name.endswith(tuple(SUPPORTED_FILE_TYPES)):
+                    return ActionResponse(
+                        message=f"Unsupported file type: {file_name}. Supported types are: {SUPPORTED_FILE_TYPES}",
+                        error_info=ErrorInfo(f"Unsupported file type: {file_name}")
+                    )
+
+                try:
+                    _, buffer, meta = file_service.resolve_url(url, session_id, return_extra=True)
+                except Exception as e:
+                    log.error("Error resolving file URL: %s", e)
+                    return ActionResponse(
+                        message=f"Error resolving file URL: {str(e)}",
+                        error_info=ErrorInfo(str(e))
+                    )
+                
+                total_size += len(buffer)
+                if total_size > MAX_FILE_LENGTH:
+                    return ActionResponse(
+                        message=f"Total file size exceeds {MAX_FILE_LENGTH} bytes.",
+                        error_info=ErrorInfo(f"Total file size exceeds {MAX_FILE_LENGTH} bytes.")
+                    )
+
+                byte_content = base64.b64encode(buffer).decode('utf-8')
+                byte_contents.append({
+                    'name': meta.get("name"),
+                    'source': {
+                        'byteContent': {
+                            'data': byte_content,
+                            'mediaType': meta.get("mime_type"),
+                        },
+                        'sourceType': 'BYTE_CONTENT'
+                    },
+                    'useCase': 'CHAT'
+                })
+
+            session_state = {
+                'files': byte_contents,
+            }
+            
 
         try:
             result =  self.bedrock_agent_runtime.invoke_agent(
                 self.bedrock_agent_id,
                 self.bedrock_agent_alias_id,
                 session_id,
-                user_input
+                user_input,
+                session_state
             )
             return ActionResponse(message=result)
         except ClientError as e:

--- a/sam-bedrock-agent/src/agents/bedrock_agent/bedrock_agent_agent_component.py
+++ b/sam-bedrock-agent/src/agents/bedrock_agent/bedrock_agent_agent_component.py
@@ -68,6 +68,7 @@ class BedrockAgentAgentComponent(BaseAgentComponent):
                     "bedrock_agent_id": action_config["bedrock_agent_id"],
                     "bedrock_agent_alias_id": action_config["bedrock_agent_alias_id"],
                     "param_description": action_config.get("param_description"),
+                    "allow_files": action_config.get("allow_files"),
                 },
                 self.bedrock_agent_runtime,
                 agent=self,

--- a/sam-bedrock-agent/src/agents/bedrock_agent/bedrock_agent_runtime.py
+++ b/sam-bedrock-agent/src/agents/bedrock_agent/bedrock_agent_runtime.py
@@ -11,7 +11,7 @@ class BedrockAgentRuntime:
         session = boto3.Session(**boto3_config)
         self.agents_runtime_client = session.client("bedrock-agent-runtime", endpoint_url=endpoint_url)
 
-    def invoke_agent(self, agent_id, agent_alias_id, session_id, prompt):
+    def invoke_agent(self, agent_id, agent_alias_id, session_id, prompt, session_state=None):
         """
         Sends a prompt for the agent to process and respond to.
 
@@ -20,6 +20,7 @@ class BedrockAgentRuntime:
         :param session_id: The unique identifier of the session. Use the same value across requests
                            to continue the same conversation.
         :param prompt: The prompt that you want model to complete.
+        :param session_state: The state of the session.
         :return: Inference response from the model.
         """
 
@@ -29,6 +30,7 @@ class BedrockAgentRuntime:
                 agentAliasId=agent_alias_id,
                 sessionId=session_id,
                 inputText=prompt,
+                sessionState=session_state,
             )
 
             completion = ""
@@ -64,8 +66,8 @@ class BedrockAgentRuntime:
             result = ""
 
             # Get the streaming response
-            for event in response['responseStream']:
-                result = result + str(event) + '\n'
+            for event in response["responseStream"]:
+                result = result + str(event) + "\n"
 
         except ClientError as e:
             log.error("Couldn't invoke flow %s.", {e})


### PR DESCRIPTION
## What is the purpose of this change?

To add support for file attachments in Amazon Bedrock Agents, allowing users to upload and process files when interacting with agents.

## How is this accomplished?

- Added Amazon bedrock agents file attachment support
- Implemented file validation for supported formats (.pdf, .txt, .doc, .csv, .xls, .xlsx)
- Added configuration parameter `allow_files` to control file upload capability
- Modified the agent invocation logic to handle file attachments through the session state
- Updated configuration files and documentation to reflect new capabilities

## Anything reviews should focus on/be aware of?

The implementation adheres to Amazon Bedrock's limits of 5 files maximum with 10MB total size. File validation is performed before uploading to ensure only supported file types are processed.