### PR TITLE
AI-799: Set MCP env vars from calling process

### DIFF
--- a/sam-mcp-server/README.md
+++ b/sam-mcp-server/README.md
@@ -48,6 +48,26 @@ export SERVER_EVERYTHING_DEV_SERVER_COMMAND="npx -y @modelcontextprotocol/server
 # Optional: export SERVER_EVERYTHING_DEV_SERVER_DESCRIPTION="General purpose MCP server for development."
 ```
 
+### Passing Environment Variables to MCP Servers
+
+By default, no environment variables are passed to the MCP server process. You can explicitly specify which environment variables should be passed using the `environment_variables` configuration option in your agent's YAML file:
+
+```yaml
+shared_config:
+  - mcp_server_info: &mcp_server_info
+      # Other server configuration...
+      
+      # Optional: Specify environment variables to pass to the MCP server process
+      environment_variables:
+        MY_API_KEY: ${SECRET_API_KEY}
+        ANOTHER_VAR: "some_static_value"
+```
+
+Benefits of this approach:
+- **Security**: Only explicitly defined environment variables are passed to the MCP server process
+- **Clarity**: Configuration is more explicit about which variables are needed
+- **Flexibility**: You can reference existing environment variables using the `${VAR_NAME}` syntax
+
 ## How it Works
 
 The `mcp_server` agent starts the process specified by the `*_SERVER_COMMAND` environment variable. It communicates with this process using standard input/output (stdio) according to the MCP specification.

--- a/sam-mcp-server/README.md
+++ b/sam-mcp-server/README.md
@@ -50,23 +50,34 @@ export SERVER_EVERYTHING_DEV_SERVER_COMMAND="npx -y @modelcontextprotocol/server
 
 ### Passing Environment Variables to MCP Servers
 
-By default, no environment variables are passed to the MCP server process. You can explicitly specify which environment variables should be passed using the `environment_variables` configuration option in your agent's YAML file:
+By default, no environment variables are passed to the MCP server process. You can explicitly specify which environment variables should be passed using two configuration options in your agent's YAML file: `environment_file` and `environment_variables`.
+
+1.  **`environment_file` (Optional)**: Path to a file containing environment variables in the standard `.env` format (key-value pairs, one per line).
+2.  **`environment_variables` (Optional)**: A dictionary where you can define environment variables directly.
+
+**Precedence**: Variables defined directly in `environment_variables` will **override** any variables with the same name loaded from the `environment_file`.
+
+**Example:**
 
 ```yaml
 shared_config:
   - mcp_server_info: &mcp_server_info
       # Other server configuration...
       
-      # Optional: Specify environment variables to pass to the MCP server process
+      # Optional: Load variables from a .env file
+      environment_file: .env.mcp.production
+      
+      # Optional: Define variables directly (these override .env.production)
       environment_variables:
-        MY_API_KEY: ${SECRET_API_KEY}
+        MY_API_KEY: ${SECRET_API_KEY} # Reference another env var
         ANOTHER_VAR: "some_static_value"
+        DEBUG_MODE: "false" # Overrides DEBUG_MODE if it was in .env.production
 ```
 
-Benefits of this approach:
-- **Security**: Only explicitly defined environment variables are passed to the MCP server process
-- **Clarity**: Configuration is more explicit about which variables are needed
-- **Flexibility**: You can reference existing environment variables using the `${VAR_NAME}` syntax
+**Benefits:**
+- **Security**: Only explicitly defined or loaded environment variables are passed.
+- **Clarity**: Configuration clearly shows variable sources.
+- **Flexibility**: Use `.env` files for common variables and override specific ones directly. You can also reference existing host environment variables using the `${VAR_NAME}` syntax within the `environment_variables` dictionary.
 
 ## How it Works
 

--- a/sam-mcp-server/configs/agents/mcp_server.yaml
+++ b/sam-mcp-server/configs/agents/mcp_server.yaml
@@ -33,8 +33,14 @@ shared_config:
       server_description: &mcp_server_description ${{{SNAKE_UPPER_CASE_NAME}}_SERVER_DESCRIPTION, "Provides access to the {{SNAKE_CASE_NAME}} MCP server"}
       server_command: &mcp_server_command ${{{SNAKE_UPPER_CASE_NAME}}_SERVER_COMMAND}
       server_subscription_topic: &mcp_sub_topic ${SOLACE_AGENT_MESH_NAMESPACE}solace-agent-mesh/v1/actionRequest/*/*/{{SNAKE_CASE_NAME}}/>
-      # Optional: Specify environment variables to pass to the MCP server process.
+      
+      # Optional: Path to a file (e.g., .env format) containing environment variables.
+      # Variables defined in 'environment_variables' below will override those from this file.
+      # environment_file: .env
+      
+      # Optional: Specify environment variables directly to pass to the MCP server process.
       # Values can reference existing environment variables using ${VAR_NAME}.
+      # These will override variables loaded from 'environment_file'.
       # environment_variables:
       #   MY_API_KEY: ${SECRET_API_KEY}
       #   ANOTHER_VAR: "some_static_value"

--- a/sam-mcp-server/configs/agents/mcp_server.yaml
+++ b/sam-mcp-server/configs/agents/mcp_server.yaml
@@ -33,6 +33,11 @@ shared_config:
       server_description: &mcp_server_description ${{{SNAKE_UPPER_CASE_NAME}}_SERVER_DESCRIPTION, "Provides access to the {{SNAKE_CASE_NAME}} MCP server"}
       server_command: &mcp_server_command ${{{SNAKE_UPPER_CASE_NAME}}_SERVER_COMMAND}
       server_subscription_topic: &mcp_sub_topic ${SOLACE_AGENT_MESH_NAMESPACE}solace-agent-mesh/v1/actionRequest/*/*/{{SNAKE_CASE_NAME}}/>
+      # Optional: Specify environment variables to pass to the MCP server process.
+      # Values can reference existing environment variables using ${VAR_NAME}.
+      # environment_variables:
+      #   MY_API_KEY: ${SECRET_API_KEY}
+      #   ANOTHER_VAR: "some_static_value"
 
 flows:
   # Flow to handle action requests

--- a/sam-mcp-server/pyproject.toml
+++ b/sam-mcp-server/pyproject.toml
@@ -15,7 +15,8 @@ description = "This adds both an agent to talk to MCP servers and a gateway for 
 readme = "README.md"
 requires-python = ">=3.10.16"
 dependencies = [
-  "mcp>=0.9.1"
+  "mcp>=0.9.1",
+  "python-dotenv>=1.0.1"
 ]
 
 [tool.hatch.build.targets.wheel.force-include]

--- a/sam-mcp-server/src/agents/mcp_server/mcp_server_agent_component.py
+++ b/sam-mcp-server/src/agents/mcp_server/mcp_server_agent_component.py
@@ -101,6 +101,13 @@ info.update(
                 "type": "boolean",
                 "default": False,
             },
+            {
+                "name": "environment_variables",
+                "required": False,
+                "description": "Dictionary of environment variables to pass to the MCP server process",
+                "type": "object",
+                "default": {},
+            },
         ],
     }
 )
@@ -192,10 +199,14 @@ class McpServerAgentComponent(BaseAgentComponent):
                     from .async_server import AsyncServerThread
 
                     parts = server_command.split()
+                    
+                    # Get configured environment variables or empty dict if not specified
+                    server_env = self.get_config("environment_variables", {})
+                    
                     server_params = StdioServerParameters(
                         command=parts[0],
                         args=parts[1:],
-                        env=os.environ,  # Use current process environment
+                        env=server_env,  # Use configured environment variables
                     )
 
                     # Create and start async server thread

--- a/sam-mcp-server/src/agents/mcp_server/mcp_server_agent_component.py
+++ b/sam-mcp-server/src/agents/mcp_server/mcp_server_agent_component.py
@@ -104,9 +104,16 @@ info.update(
             {
                 "name": "environment_variables",
                 "required": False,
-                "description": "Dictionary of environment variables to pass to the MCP server process",
+                "description": "Dictionary of environment variables to pass to the MCP server process. Overrides variables from environment_file.",
                 "type": "object",
                 "default": {},
+            },
+            {
+                "name": "environment_file",
+                "required": False,
+                "description": "Path to a file (e.g., .env format) containing environment variables for the MCP server process.",
+                "type": "string",
+                "default": None,
             },
         ],
     }
@@ -195,18 +202,39 @@ class McpServerAgentComponent(BaseAgentComponent):
                         "SSE mode not yet supported with async thread"
                     )
                 else:  # stdio mode
+                    import os
+                    import dotenv
                     from mcp import StdioServerParameters
                     from .async_server import AsyncServerThread
 
                     parts = server_command.split()
                     
-                    # Get configured environment variables or empty dict if not specified
-                    server_env = self.get_config("environment_variables", {})
+                    # Load environment variables
+                    final_env = {}
+                    env_file_path = self.get_config("environment_file")
+                    direct_env_vars = self.get_config("environment_variables", {})
+
+                    # Load from file first, if specified and exists
+                    if env_file_path:
+                        # Ensure the path is absolute or relative to a known location if needed
+                        # For simplicity, assuming relative to SAM execution or absolute path
+                        if os.path.exists(env_file_path):
+                            try:
+                                file_env = dotenv.dotenv_values(env_file_path)
+                                final_env.update(file_env)
+                                log.info(f"Loaded environment variables from {env_file_path}")
+                            except Exception as e:
+                                log.warning(f"Failed to load environment variables from {env_file_path}: {e}")
+                        else:
+                            log.warning(f"Environment file specified but not found: {env_file_path}")
+                    
+                    # Merge/override with directly configured variables
+                    final_env.update(direct_env_vars)
                     
                     server_params = StdioServerParameters(
                         command=parts[0],
                         args=parts[1:],
-                        env=server_env,  # Use configured environment variables
+                        env=final_env,  # Use merged environment variables
                     )
 
                     # Create and start async server thread

--- a/sam-mcp-server/src/agents/mcp_server/mcp_server_agent_component.py
+++ b/sam-mcp-server/src/agents/mcp_server/mcp_server_agent_component.py
@@ -5,6 +5,7 @@ agents, converting their capabilities into actions.
 """
 
 import copy
+import os
 from typing import Dict, Any, Optional
 
 from solace_agent_mesh.agents.base_agent_component import (
@@ -194,7 +195,7 @@ class McpServerAgentComponent(BaseAgentComponent):
                     server_params = StdioServerParameters(
                         command=parts[0],
                         args=parts[1:],
-                        env=None,  # Use default safe environment
+                        env=os.environ,  # Use current process environment
                     )
 
                     # Create and start async server thread


### PR DESCRIPTION
When creating the MCP thread, copy the environment from the calling process into the thread so the MCP Server has access to them.