### PR TITLE
DATAGO-107559: Fix slack permission error

### DIFF
--- a/sam-slack/src/sam_slack/component.py
+++ b/sam-slack/src/sam_slack/component.py
@@ -181,10 +181,7 @@ class SlackGatewayComponent(BaseGatewayComponent):
 
             @self.slack_app.event("message")
             async def handle_message_events_async(event, say, client, body):
-                ensure_team_id_in_event(event, body)                                                                                                                                                                                       
-                log.debug(                                                                                                                                                                                                            
-                    "%s Received Slack 'message' event (async).", self.log_identifier                                                                                                                                                 
-                )  
+                ensure_team_id_in_event(event, body)                                                                                                                                                                                     
                 log.debug(
                     "%s Received Slack 'message' event (async).", self.log_identifier
                 )

--- a/sam-slack/src/sam_slack/component.py
+++ b/sam-slack/src/sam_slack/component.py
@@ -142,7 +142,6 @@ class SlackGatewayComponent(BaseGatewayComponent):
 
             from . import handlers
 
-            # ensure team_id is always present in events
             def ensure_team_id_in_event(event, raw_event_body):
                 if "team" not in event and "team_id" not in event:
                     if team_id := raw_event_body.get("team_id"):


### PR DESCRIPTION
`team_id` was missing in the fileshare event, this change ensure team id is always present by looking at the raw object and extracting it if needed