### PR TITLE
DATAGO-108158: Fix slack gateway issue with dereferencing files

### DIFF
--- a/sam-slack/src/sam_slack/component.py
+++ b/sam-slack/src/sam_slack/component.py
@@ -825,27 +825,18 @@ class SlackGatewayComponent(BaseGatewayComponent):
                     )
                 elif file_info.get("uri"):
                     log.info("%s Dereferencing artifact URI: %s", log_id, file_info['uri'])
-                    try:
-                        # Parse the URI to get the artifact's true context
-                        parsed_uri = urlparse(file_info['uri'])
-                        if parsed_uri.scheme != "artifact":
-                            raise ValueError("Invalid URI scheme, must be 'artifact'.")
-                        
-                        app_name = parsed_uri.netloc
-                        path_parts = parsed_uri.path.strip("/").split("/")
-                        if len(path_parts) != 3:
-                            raise ValueError("Invalid URI path structure.")
-                        
-                        owner_user_id, owner_session_id, filename = path_parts
-                        query_params = parse_qs(parsed_uri.query)
-                        version_list = query_params.get("version")
-                        if not version_list or not version_list[0]:
-                            raise ValueError("Version query parameter is required.")
-                        version = int(version_list[0])
 
-                        log.info(
-                            "%s Parsed URI: app=%s, owner=%s, session=%s, file=%s, version=%s",
-                            log_id, app_name, owner_user_id, owner_session_id, filename, version
+                    try:                                                                                                                                                                             
+                        parsed = self._parse_artifact_uri(file_info['uri'])                                                                                                                          
+                        app_name = parsed["app_name"]                                                                                                                                                
+                        owner_user_id = parsed["user_id"]                                                                                                                                            
+                        owner_session_id = parsed["session_id"]                                                                                                                                      
+                        filename = parsed["filename"]                                                                                                                                                
+                        version = parsed["version"]                                                                                                                                                  
+                                                                                                                                                                                                     
+                        log.info(                                                                                                                                                                    
+                            "%s Parsed URI: app=%s, owner=%s, session=%s, file=%s, version=%s",                                                                                                      
+                            log_id, app_name, owner_user_id, owner_session_id, filename, version                                                                                                     
                         )
 
                         # Check if user owns the artifact

--- a/sam-slack/src/sam_slack/component.py
+++ b/sam-slack/src/sam_slack/component.py
@@ -848,6 +848,17 @@ class SlackGatewayComponent(BaseGatewayComponent):
                             log_id, app_name, owner_user_id, owner_session_id, filename, version
                         )
 
+                        # Check if user owns the artifact
+                        current_user_id = external_request_context.get("user_id_for_artifacts")
+                        if owner_user_id != current_user_id:
+                            log.warning(
+                                "%s User %s denied access to artifact owned by %s", 
+                                log_id, current_user_id, owner_user_id
+                            )
+                            error_msg = f":warning: Access denied to artifact `{filename}`."
+                            await send_slack_message(self, channel_id, thread_ts, error_msg)
+                            continue
+
                         # Load the artifact content using the shared service
                         load_result = await load_artifact_content_or_metadata(
                             artifact_service=self.shared_artifact_service,

--- a/sam-slack/src/sam_slack/component.py
+++ b/sam-slack/src/sam_slack/component.py
@@ -863,7 +863,6 @@ class SlackGatewayComponent(BaseGatewayComponent):
                         )
 
                         if load_result.get("status") == "success" and load_result.get("raw_bytes"):
-                            # If successful, upload the fetched bytes to Slack
                             log.info(
                                 "%s Successfully loaded artifact content (%d bytes). Uploading to Slack.",
                                 log_id, len(load_result["raw_bytes"])

--- a/sam-slack/src/sam_slack/component.py
+++ b/sam-slack/src/sam_slack/component.py
@@ -843,14 +843,13 @@ class SlackGatewayComponent(BaseGatewayComponent):
                         current_user_id = external_request_context.get("user_id_for_artifacts")
                         if owner_user_id != current_user_id:
                             log.warning(
-                                "%s User %s denied access to artifact owned by %s", 
-                                log_id, current_user_id, owner_user_id
+                                "%s User %s denied access to artifact.", 
+                                log_id, current_user_id
                             )
                             error_msg = f":warning: Access denied to artifact `{filename}`."
                             await send_slack_message(self, channel_id, thread_ts, error_msg)
                             continue
 
-                        # Load the artifact content using the shared service
                         load_result = await load_artifact_content_or_metadata(
                             artifact_service=self.shared_artifact_service,
                             app_name=app_name,
@@ -878,8 +877,7 @@ class SlackGatewayComponent(BaseGatewayComponent):
                                 load_result.get("mime_type"),
                             )
                         else:
-                            # If loading fails, notify the user in Slack
-                            error_msg = f":warning: Failed to load artifact content for `{filename}`: {load_result.get('message', 'Unknown error')}"
+                            error_msg = f":warning: Failed to load artifact content for `{filename}`"
                             await send_slack_message(self, channel_id, thread_ts, error_msg)
 
                     except (ValueError, IndexError) as e:


### PR DESCRIPTION
The slack gateway did not have the necessary handling for dereferencing artifact links. This logic is similar to the existing logic [here in the http_sse gateway](https://github.com/SolaceLabs/solace-agent-mesh/blob/main/src/solace_agent_mesh/gateway/http_sse/routers/artifacts.py#L374). This is connected to this PR in the solace-agent-mesh repo which adds the URI parsing helper to the BaseGatewayApp class.

SAM PR: 