### PR TITLE
fixes postgres error when validating schemas

### DIFF
--- a/sam-sql-database/src/sam_sql_database/services/database_service.py
+++ b/sam-sql-database/src/sam_sql_database/services/database_service.py
@@ -193,7 +193,7 @@ class DatabaseService(ABC):
         if self.engine.name == "mysql":
             query = f"SELECT DISTINCT `{column_name}` FROM `{table_name}` WHERE `{column_name}` IS NOT NULL ORDER BY RAND() LIMIT {limit}"
         elif self.engine.name == "postgresql":
-            query = f'SELECT DISTINCT "{column_name}" FROM "{table_name}" WHERE "{column_name}" IS NOT NULL ORDER BY RANDOM() LIMIT {limit}'
+            query = f'SELECT DISTINCT "{column_name}" FROM "{table_name}" WHERE "{column_name}" IS NOT NULL LIMIT {limit}'
         elif self.engine.name == "sqlite":
             query = f'SELECT DISTINCT "{column_name}" FROM "{table_name}" WHERE "{column_name}" IS NOT NULL ORDER BY RANDOM() LIMIT {limit}'
         else:


### PR DESCRIPTION
[SQL: SELECT DISTINCT "phase_description" FROM "project_phases" WHERE "phase_description" IS NOT NULL ORDER BY RANDOM() LIMIT 3]
(Background on this error at: https://sqlalche.me/e/20/f405)
2025-09-11 15:39:16,842 - solace_ai_connector - WARNING - Could not fetch unique values for project_phases.phase_description: (psycopg2.errors.InvalidColumnReference) for SELECT DISTINCT, ORDER BY expressions must appear in select list
LINE 1: ...s" WHERE "phase_description" IS NOT NULL ORDER BY RANDOM() L...
                            