### PR TITLE
fix(DATAGO-113023): Fixed postgresql init query

### DIFF
--- a/sam-sql-database/pyproject.toml
+++ b/sam-sql-database/pyproject.toml
@@ -10,7 +10,7 @@ type = "agent"
 
 [project]
 name = "sam_sql_database"
-version = "0.1.0" # Initial version
+version = "0.1.1" # Initial version
 description = "A2A ADK Host plugin for natural language querying of SQL databases."
 readme = "README.md"
 authors = [

--- a/sam-sql-database/src/sam_sql_database/services/database_service.py
+++ b/sam-sql-database/src/sam_sql_database/services/database_service.py
@@ -193,7 +193,14 @@ class DatabaseService(ABC):
         if self.engine.name == "mysql":
             query = f"SELECT DISTINCT `{column_name}` FROM `{table_name}` WHERE `{column_name}` IS NOT NULL ORDER BY RAND() LIMIT {limit}"
         elif self.engine.name == "postgresql":
-            query = f'SELECT DISTINCT "{column_name}" FROM "{table_name}" WHERE "{column_name}" IS NOT NULL ORDER BY RANDOM() LIMIT {limit}'
+            query = f'''
+            SELECT "{column_name}" FROM (
+                SELECT "{column_name}"
+                FROM "{table_name}"
+                WHERE "{column_name}" IS NOT NULL
+            ) AS distinct_values
+            ORDER BY RANDOM()
+            LIMIT {limit}'''
         elif self.engine.name == "sqlite":
             query = f'SELECT DISTINCT "{column_name}" FROM "{table_name}" WHERE "{column_name}" IS NOT NULL ORDER BY RANDOM() LIMIT {limit}'
         else:


### PR DESCRIPTION
PostgreSQL's SQL standard compliance requires that `ORDER BY` expressions in `SELECT DISTINCT` queries must appear in the select list, since the distinct operation happens before ordering.