### PR TITLE
ci(DATAGO-131317): add packages:read permission for GHCR container pull

### DIFF
--- a/.github/workflows/build-plugin.yaml
+++ b/.github/workflows/build-plugin.yaml
@@ -54,6 +54,7 @@ permissions:
   statuses: write
   checks: write
   repository-projects: read
+  packages: read
 
 env:
   PYTHON_VERSION: "3.13"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ permissions:
   checks: write
   repository-projects: read
   id-token: write
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
## Summary

- Adds `packages: read` to the workflow-level `permissions` block in `build-plugin.yaml`

## Why

CI container maas-build-actions from solacelabs needs package read permissions

## Impact

Without this change, the FOSSA guard step that pulls `ghcr.io/solacelabs/maas-build-actions` will fail with `unauthorized` once the updated SPW composite actions land on `main`.

## Test plan
- [ ] Trigger a build-plugin workflow after merging and confirm `docker login ghcr.io` succeeds
- [ ] Confirm `maas-build-actions` container pulls without `unauthorized` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)