### PR TITLE
feat(DATAGO-131375): Implement EventMeshService for request-response communication via Solace broker

### DIFF
--- a/.github/pr_labeler.yaml
+++ b/.github/pr_labeler.yaml
@@ -45,3 +45,8 @@ sam-sql-database-tool:
 sam-mcp-server-gateway-adapter:
   - changed-files:
       - any-glob-to-any-file: sam-mcp-server-gateway-adapter/**
+
+sam-event-mesh-identity-provider:
+  - changed-files:
+    - any-glob-to-any-file: sam-event-mesh-identity-provider/**
+

--- a/.github/workflows/build-plugin.yaml
+++ b/.github/workflows/build-plugin.yaml
@@ -41,6 +41,7 @@ on:
           - sam-slack-gateway-adapter
           - sam-sql-database-tool
           - sam-webhook-gateway
+          - sam-event-mesh-identity-provider
       ref:
         description: "Git ref to checkout (branch or SHA)"
         required: false

--- a/.github/workflows/deprecate-plugins.yaml
+++ b/.github/workflows/deprecate-plugins.yaml
@@ -14,6 +14,11 @@ on:
         required: false
         type: boolean
         default: false
+      sam-event-mesh-identity-provider:
+        description: "Deprecate sam-event-mesh-identity-provider"
+        required: false
+        type: boolean
+        default: false
       sam-event-mesh-tool:
         description: "Deprecate sam-event-mesh-tool"
         required: false

--- a/.github/workflows/sync-plugin-configs.yaml
+++ b/.github/workflows/sync-plugin-configs.yaml
@@ -39,6 +39,7 @@ on:
       - "!sam-sql-database/**"
       - "!sam-sql-database-tool/**"
       - "!sam-webhook-gateway/**"
+      - "!sam-event-mesh-identity-provider/**"
 
 permissions:
   contents: write

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,7 @@
 {
   "sam-bedrock-agent": "0.1.1",
   "sam-event-mesh-gateway": "1.1.0",
+  "sam-event-mesh-identity-provider": "0.1.0",
   "sam-event-mesh-tool": "0.1.1",
   "sam-mcp-server-gateway-adapter": "0.1.1",
   "sam-mongodb": "0.1.1",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -74,6 +74,10 @@
       "package-name": "sam_event_mesh_gateway",
       "changelog-path": "CHANGELOG.md"
     },
+    "sam-event-mesh-identity-provider": {
+      "package-name": "solace_agent_mesh_event_mesh_identity_provider",
+      "changelog-path": "CHANGELOG.md"
+    },
     "sam-event-mesh-tool": {
       "package-name": "sam_event_mesh_tool",
       "changelog-path": "CHANGELOG.md"

--- a/sam-event-mesh-identity-provider/.gitignore
+++ b/sam-event-mesh-identity-provider/.gitignore
@@ -1,0 +1,29 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Testing
+.pytest_cache/
+htmlcov/
+.coverage
+coverage.xml
+
+# Hatch
+.hatch/

--- a/sam-event-mesh-identity-provider/README.md
+++ b/sam-event-mesh-identity-provider/README.md
@@ -1,0 +1,355 @@
+# Event Mesh Identity Provider Plugin
+
+A generic, vendor-agnostic identity and employee service provider for [Solace Agent Mesh](https://solacelabs.github.io/solace-agent-mesh/) that communicates with any backend system via Solace Event Mesh request-response messaging.
+
+## About Solace Agent Mesh
+
+[Solace Agent Mesh](https://solacelabs.github.io/solace-agent-mesh/) is a framework for building AI agent systems that communicate over Solace event brokers. It enables multi-agent collaboration, tool integration, and gateway connectivity for AI-powered applications.
+
+## When to Use This Plugin
+
+Use this plugin when:
+
+- **You have an HR or identity system** (e.g., Workday, BambooHR, custom LDAP) that is accessible via a service connected to a Solace event broker.
+- **You need identity enrichment** in your gateway — enrich user auth claims with profile data (title, department, manager) from your HR system.
+- **You need employee directory access** in your agents — let agents look up employees, search users, fetch org structure, or retrieve profile pictures.
+- **You want a single plugin** that serves both identity and employee service roles without writing custom code.
+
+The plugin sends requests to configurable topics on your Solace broker and expects a backend service (your integration layer) to respond. This makes it compatible with **any** backend system — you just need a message-driven integration that responds on the event mesh.
+
+## Key Features
+
+- **Vendor-agnostic**: Works with any backend connected to Solace Event Mesh
+- **Configurable field mapping**: Map source fields to canonical schema via YAML (no code changes)
+- **Computed fields**: Derive values from multiple source fields (e.g., displayName from first + last name)
+- **Field exclusion and renaming**: Fine-grained control over output fields
+- **Per-operation topics**: Each operation has its own request and response topic pair
+- **Selective operations**: Only configure the operations you need — unconfigured ones gracefully return None
+- **Built-in caching**: Configurable TTL caching for all operations
+- **Dual-purpose**: Use as identity service (gateways) and/or employee service (agents)
+
+## Installation
+
+```bash
+sam plugin install sam-event-mesh-identity-provider
+```
+
+Or install directly:
+
+```bash
+pip install sam-event-mesh-identity-provider
+```
+
+## Configuration
+
+### As Identity Service (Gateway)
+
+Add to your gateway configuration to enrich user identity on each request:
+
+```yaml
+identity_service:
+  type: "event-mesh-identity-provider"
+
+  broker_url: "${IDENTITY_BROKER_URL}"
+  broker_vpn: "${IDENTITY_BROKER_VPN}"
+  broker_username: "${IDENTITY_BROKER_USERNAME}"
+  broker_password: "${IDENTITY_BROKER_PASSWORD}"
+
+  lookup_key: "email"
+  cache_ttl_seconds: 3600
+  request_expiry_ms: 120000
+  response_topic_prefix: "mycompany/identity/response"
+
+  # Only configure the operations you need. Unconfigured operations
+  # will return None with a warning log.
+  operations:
+    user_profile:
+      request_topic: "mycompany/identity/user-profile/request/v1/{request_id}"
+      response_topic: "mycompany/identity/user-profile/response/v1/"
+    search_users:
+      request_topic: "mycompany/identity/search-users/request/v1/{request_id}"
+      response_topic: "mycompany/identity/search-users/response/v1/"
+
+  field_mapping_config:
+    field_mapping:
+      emp_email: "workEmail"
+      title: "jobTitle"
+      dept_name: "department"
+    computed_fields:
+      - target: "displayName"
+        source_fields: ["first_name", "last_name"]
+        separator: " "
+    pass_through_unmapped: true
+```
+
+### As People/Employee Service (Agent)
+
+Add to your agent configuration for employee directory access:
+
+```yaml
+people_service:
+  type: "event-mesh-identity-provider"
+
+  broker_url: "${IDENTITY_BROKER_URL}"
+  broker_vpn: "${IDENTITY_BROKER_VPN}"
+  broker_username: "${IDENTITY_BROKER_USERNAME}"
+  broker_password: "${IDENTITY_BROKER_PASSWORD}"
+
+  lookup_key: "email"
+  cache_ttl_seconds: 3600
+  response_topic_prefix: "mycompany/identity/response"
+
+  operations:
+    user_profile:
+      request_topic: "mycompany/identity/user-profile/request/v1/{request_id}"
+      response_topic: "mycompany/identity/user-profile/response/v1/"
+    search_users:
+      request_topic: "mycompany/identity/search-users/request/v1/{request_id}"
+      response_topic: "mycompany/identity/search-users/response/v1/"
+    employee_data:
+      request_topic: "mycompany/identity/employee-data/request/v1/{request_id}"
+      response_topic: "mycompany/identity/employee-data/response/v1/"
+    employee_profile:
+      request_topic: "mycompany/identity/employee-profile/request/v1/{request_id}"
+      response_topic: "mycompany/identity/employee-profile/response/v1/"
+    time_off:
+      request_topic: "mycompany/identity/time-off/request/v1/{request_id}"
+      response_topic: "mycompany/identity/time-off/response/v1/"
+    profile_picture:
+      request_topic: "mycompany/identity/profile-picture/request/v1/{request_id}"
+      response_topic: "mycompany/identity/profile-picture/response/v1/"
+
+  field_mapping_config:
+    field_mapping: {}
+    pass_through_unmapped: true
+```
+
+## Migration from a Custom Identity Provider
+
+If you are migrating from a vendor-specific identity provider plugin to this generic one:
+
+1. Install the new plugin: `sam plugin install sam-event-mesh-identity-provider`
+2. Change `type` to `"event-mesh-identity-provider"`
+3. Move your topics into the `operations` dict with both `request_topic` and `response_topic`
+4. Add a `field_mapping_config` section to replicate any hardcoded field mappings from your old provider
+
+**Example — before (custom provider):**
+```yaml
+identity_service:
+  type: "my-custom-provider"
+  broker_url: "${HR_BROKER_URL}"
+  broker_vpn: "${HR_BROKER_VPN}"
+  broker_username: "${HR_BROKER_USERNAME}"
+  broker_password: "${HR_BROKER_PASSWORD}"
+  request_topic: "company/hr/user/requested/v1/{request_id}"
+  response_topic: "company/hr/user/retrieved/v1/"
+  lookup_key: "email"
+  cache_ttl_seconds: 3600
+```
+
+**Example — after (event-mesh-identity-provider):**
+```yaml
+identity_service:
+  type: "event-mesh-identity-provider"
+  broker_url: "${HR_BROKER_URL}"
+  broker_vpn: "${HR_BROKER_VPN}"
+  broker_username: "${HR_BROKER_USERNAME}"
+  broker_password: "${HR_BROKER_PASSWORD}"
+  lookup_key: "email"
+  cache_ttl_seconds: 3600
+  response_topic_prefix: "company/hr/user/retrieved/v1/"
+
+  operations:
+    user_profile:
+      request_topic: "company/hr/user/requested/v1/{request_id}"
+      response_topic: "company/hr/user/retrieved/v1/"
+
+  field_mapping_config:
+    field_mapping:
+      emp_email: "workEmail"
+      position: "jobTitle"
+    computed_fields:
+      - target: "displayName"
+        source_fields: ["firstName", "middleName", "lastName"]
+        separator: " "
+      - target: "id"
+        source_fields: ["emp_email"]
+        separator: ""
+    pass_through_unmapped: true
+```
+
+Only the operations you configure are active. If your old provider only handled user profile lookups, you only need to configure `user_profile`. Add more operations as your backend integration supports them.
+
+## Configuration Reference
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `type` | Must be `"event-mesh-identity-provider"` | Required |
+| `broker_url` | Solace broker URL | Required |
+| `broker_vpn` | Solace message VPN name | Required |
+| `broker_username` | Broker authentication username | Required |
+| `broker_password` | Broker authentication password | Required |
+| `dev_mode` | Enable development mode (no TLS verification) | `false` |
+| `lookup_key` | Key in auth_claims used to look up the user | `"email"` |
+| `cache_ttl_seconds` | Cache TTL in seconds (0 to disable) | `3600` |
+| `request_expiry_ms` | Request timeout in milliseconds | `120000` |
+| `response_topic_prefix` | Prefix for the response correlation topic | `"sam/identity-provider/response"` |
+| `operations` | Dict of per-operation topic configs (each with `request_topic` and `response_topic`) | `{}` |
+| `field_mapping_config` | Field transformation configuration | `{}` (passthrough) |
+
+## Field Mapping Guide
+
+The field mapping engine transforms source data through a three-phase pipeline:
+
+```
+Source Data → [1. Field Mapping] → [2. Exclusion] → [3. Renaming] → Output
+                                ↑
+                    [Computed Fields]
+```
+
+### Phase 1: field_mapping
+
+Rename source fields to canonical names:
+
+```yaml
+field_mapping:
+  emp_email: "workEmail"       # "emp_email" in source → "workEmail" in output
+  position: "jobTitle"         # "position" in source → "jobTitle" in output
+```
+
+### Computed Fields
+
+Derive values from multiple source fields:
+
+```yaml
+computed_fields:
+  # Concatenation (skips empty parts)
+  - target: "displayName"
+    source_fields: ["firstName", "middleName", "lastName"]
+    separator: " "
+
+  # Template-based (with fallback to concatenation if template fails)
+  - target: "fullAddress"
+    source_fields: ["city", "country"]
+    template: "{city}, {country}"
+```
+
+### Phase 2: exclusion_list
+
+Remove fields from output:
+
+```yaml
+exclusion_list:
+  - "mobilePhone"       # Don't expose phone numbers
+  - "salaryStructure"   # Don't expose salary data
+```
+
+### Phase 3: rename_mapping
+
+Rename fields in the final output:
+
+```yaml
+rename_mapping:
+  supervisorId: "managerId"    # Rename for downstream consumers
+  workEmail: "email"           # Simplify field name
+```
+
+### Zero-Configuration
+
+If your backend already returns data using the canonical field names (`id`, `displayName`, `workEmail`, `jobTitle`, `department`, `location`, `supervisorId`, `hireDate`, `mobilePhone`), you don't need any field mapping configuration. Just leave `field_mapping_config` empty or omit it entirely.
+
+## Backend Integration Guide
+
+Your backend service needs to listen on the configured topics and respond. Here's what each operation expects:
+
+### user_profile
+
+**Request payload:**
+```json
+{"email": "jane@company.com"}
+```
+
+**Expected response:** A single employee record (dict).
+
+### search_users
+
+**Request payload:**
+```json
+{"query": "jan", "limit": 10}
+```
+
+**Expected response:** A list of user dicts, or `{"results": [...]}`.
+
+### employee_data
+
+**Request payload:**
+```json
+{}
+```
+
+**Expected response:** A list of all employee dicts, or `{"employees": [...]}`.
+
+### employee_profile
+
+**Request payload:**
+```json
+{"employee_id": "jane@company.com"}
+```
+
+**Expected response:** A single employee record (dict).
+
+### time_off
+
+**Request payload:**
+```json
+{"employee_id": "jane@company.com", "start_date": "2025-01-01", "end_date": "2025-12-31"}
+```
+
+**Expected response:** A list of time-off entry dicts, or `{"entries": [...]}`.
+Each entry must contain: `start` (YYYY-MM-DD), `end` (YYYY-MM-DD), `type` (string), `amount` ("full_day" or "half_day").
+
+### profile_picture
+
+**Request payload:**
+```json
+{"employee_id": "jane@company.com"}
+```
+
+**Expected response:** A data URI string (e.g., `"data:image/jpeg;base64,..."`) or `{"data_uri": "..."}`.
+
+## Canonical Employee Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique, stable, lowercase identifier |
+| `displayName` | string | Full name for display |
+| `workEmail` | string | Primary work email |
+| `jobTitle` | string | Official job title |
+| `department` | string | Department name |
+| `location` | string | Physical/regional location |
+| `supervisorId` | string | Manager's unique id |
+| `hireDate` | string | ISO 8601 date (YYYY-MM-DD) |
+| `mobilePhone` | string | Mobile phone number |
+
+Additional fields from your backend are passed through by default (when `pass_through_unmapped: true`).
+
+## Development
+
+```bash
+# Clone the repository
+git clone https://github.com/SolaceLabs/solace-agent-mesh-core-plugins.git
+cd solace-agent-mesh-core-plugins/sam-event-mesh-identity-provider
+
+# Install in development mode
+pip install -e .
+
+# Install test dependencies
+pip install pytest pytest-asyncio pytest-mock pytest-cov
+
+# Run tests
+pytest tests/ -v
+
+# Run with coverage
+pytest tests/ --cov=sam_event_mesh_identity_provider --cov-report=term-missing
+```
+

--- a/sam-event-mesh-identity-provider/README.md
+++ b/sam-event-mesh-identity-provider/README.md
@@ -123,6 +123,8 @@ people_service:
 | `cache_ttl_seconds` | Cache TTL in seconds (0 to disable) | `3600` |
 | `request_expiry_ms` | Request timeout in milliseconds | `120000` |
 | `response_topic_prefix` | Prefix for the response correlation topic | `"sam/identity-provider/response"` |
+| `user_properties_reply_topic_key` | Key in message user properties where the reply topic is stored | `"replyTopic"` |
+| `response_topic_insertion_expression` | Expression used by the broker to insert the response topic into the request | `"replyTopic"` |
 | `request_topic` | Topic template (string) or per-operation map (dict) | Required |
 | `field_mapping_config` | Field transformation configuration | `{}` (passthrough) |
 

--- a/sam-event-mesh-identity-provider/README.md
+++ b/sam-event-mesh-identity-provider/README.md
@@ -119,7 +119,8 @@ people_service:
 | `broker_username` | Broker authentication username | Required |
 | `broker_password` | Broker authentication password | Required |
 | `dev_mode` | Enable development mode (no TLS verification) | `false` |
-| `lookup_key` | Key in auth_claims used to look up the user | `"email"` |
+| `lookup_key` | Key in auth_claims used to extract the lookup value | `"email"` |
+| `payload_key` | Key name used in the request payload sent to the backend | Value of `lookup_key` |
 | `cache_ttl_seconds` | Cache TTL in seconds (0 to disable) | `3600` |
 | `request_expiry_ms` | Request timeout in milliseconds | `120000` |
 | `response_topic_prefix` | Prefix for the response correlation topic | `"sam/identity-provider/response"` |

--- a/sam-event-mesh-identity-provider/README.md
+++ b/sam-event-mesh-identity-provider/README.md
@@ -10,7 +10,7 @@ A generic, vendor-agnostic identity and employee service provider for [Solace Ag
 
 Use this plugin when:
 
-- **You have an HR or identity system** (e.g., Workday, BambooHR, custom LDAP) that is accessible via a service connected to a Solace event broker.
+- **You have an HR or identity system** (e.g., SAP SuccessFactors, Workday, BambooHR, custom LDAP) that is accessible via a service connected to a Solace event broker.
 - **You need identity enrichment** in your gateway — enrich user auth claims with profile data (title, department, manager) from your HR system.
 - **You need employee directory access** in your agents — let agents look up employees, search users, fetch org structure, or retrieve profile pictures.
 - **You want a single plugin** that serves both identity and employee service roles without writing custom code.
@@ -23,8 +23,7 @@ The plugin sends requests to configurable topics on your Solace broker and expec
 - **Configurable field mapping**: Map source fields to canonical schema via YAML (no code changes)
 - **Computed fields**: Derive values from multiple source fields (e.g., displayName from first + last name)
 - **Field exclusion and renaming**: Fine-grained control over output fields
-- **Per-operation topics**: Each operation has its own request and response topic pair
-- **Selective operations**: Only configure the operations you need — unconfigured ones gracefully return None
+- **Flexible topic configuration**: Single topic string for all operations, or per-operation dict
 - **Built-in caching**: Configurable TTL caching for all operations
 - **Dual-purpose**: Use as identity service (gateways) and/or employee service (agents)
 
@@ -60,15 +59,13 @@ identity_service:
   request_expiry_ms: 120000
   response_topic_prefix: "mycompany/identity/response"
 
-  # Only configure the operations you need. Unconfigured operations
-  # will return None with a warning log.
-  operations:
-    user_profile:
-      request_topic: "mycompany/identity/user-profile/request/v1/{request_id}"
-      response_topic: "mycompany/identity/user-profile/response/v1/"
-    search_users:
-      request_topic: "mycompany/identity/search-users/request/v1/{request_id}"
-      response_topic: "mycompany/identity/search-users/response/v1/"
+  # Single topic for all operations:
+  # request_topic: "mycompany/identity/request/v1/{request_id}"
+
+  # Or per-operation topics:
+  request_topic:
+    user_profile: "mycompany/identity/user-profile/request/v1/{request_id}"
+    search_users: "mycompany/identity/search-users/request/v1/{request_id}"
 
   field_mapping_config:
     field_mapping:
@@ -99,86 +96,18 @@ people_service:
   cache_ttl_seconds: 3600
   response_topic_prefix: "mycompany/identity/response"
 
-  operations:
-    user_profile:
-      request_topic: "mycompany/identity/user-profile/request/v1/{request_id}"
-      response_topic: "mycompany/identity/user-profile/response/v1/"
-    search_users:
-      request_topic: "mycompany/identity/search-users/request/v1/{request_id}"
-      response_topic: "mycompany/identity/search-users/response/v1/"
-    employee_data:
-      request_topic: "mycompany/identity/employee-data/request/v1/{request_id}"
-      response_topic: "mycompany/identity/employee-data/response/v1/"
-    employee_profile:
-      request_topic: "mycompany/identity/employee-profile/request/v1/{request_id}"
-      response_topic: "mycompany/identity/employee-profile/response/v1/"
-    time_off:
-      request_topic: "mycompany/identity/time-off/request/v1/{request_id}"
-      response_topic: "mycompany/identity/time-off/response/v1/"
-    profile_picture:
-      request_topic: "mycompany/identity/profile-picture/request/v1/{request_id}"
-      response_topic: "mycompany/identity/profile-picture/response/v1/"
+  request_topic:
+    user_profile: "mycompany/identity/user-profile/request/v1/{request_id}"
+    search_users: "mycompany/identity/search-users/request/v1/{request_id}"
+    employee_data: "mycompany/identity/employee-data/request/v1/{request_id}"
+    employee_profile: "mycompany/identity/employee-profile/request/v1/{request_id}"
+    time_off: "mycompany/identity/time-off/request/v1/{request_id}"
+    profile_picture: "mycompany/identity/profile-picture/request/v1/{request_id}"
 
   field_mapping_config:
     field_mapping: {}
     pass_through_unmapped: true
 ```
-
-## Migration from a Custom Identity Provider
-
-If you are migrating from a vendor-specific identity provider plugin to this generic one:
-
-1. Install the new plugin: `sam plugin install sam-event-mesh-identity-provider`
-2. Change `type` to `"event-mesh-identity-provider"`
-3. Move your topics into the `operations` dict with both `request_topic` and `response_topic`
-4. Add a `field_mapping_config` section to replicate any hardcoded field mappings from your old provider
-
-**Example — before (custom provider):**
-```yaml
-identity_service:
-  type: "my-custom-provider"
-  broker_url: "${HR_BROKER_URL}"
-  broker_vpn: "${HR_BROKER_VPN}"
-  broker_username: "${HR_BROKER_USERNAME}"
-  broker_password: "${HR_BROKER_PASSWORD}"
-  request_topic: "company/hr/user/requested/v1/{request_id}"
-  response_topic: "company/hr/user/retrieved/v1/"
-  lookup_key: "email"
-  cache_ttl_seconds: 3600
-```
-
-**Example — after (event-mesh-identity-provider):**
-```yaml
-identity_service:
-  type: "event-mesh-identity-provider"
-  broker_url: "${HR_BROKER_URL}"
-  broker_vpn: "${HR_BROKER_VPN}"
-  broker_username: "${HR_BROKER_USERNAME}"
-  broker_password: "${HR_BROKER_PASSWORD}"
-  lookup_key: "email"
-  cache_ttl_seconds: 3600
-  response_topic_prefix: "company/hr/user/retrieved/v1/"
-
-  operations:
-    user_profile:
-      request_topic: "company/hr/user/requested/v1/{request_id}"
-      response_topic: "company/hr/user/retrieved/v1/"
-
-  field_mapping_config:
-    field_mapping:
-      emp_email: "workEmail"
-      position: "jobTitle"
-    computed_fields:
-      - target: "displayName"
-        source_fields: ["firstName", "middleName", "lastName"]
-        separator: " "
-      - target: "id"
-        source_fields: ["emp_email"]
-        separator: ""
-    pass_through_unmapped: true
-```
-
-Only the operations you configure are active. If your old provider only handled user profile lookups, you only need to configure `user_profile`. Add more operations as your backend integration supports them.
 
 ## Configuration Reference
 
@@ -194,17 +123,34 @@ Only the operations you configure are active. If your old provider only handled 
 | `cache_ttl_seconds` | Cache TTL in seconds (0 to disable) | `3600` |
 | `request_expiry_ms` | Request timeout in milliseconds | `120000` |
 | `response_topic_prefix` | Prefix for the response correlation topic | `"sam/identity-provider/response"` |
-| `operations` | Dict of per-operation topic configs (each with `request_topic` and `response_topic`) | `{}` |
+| `request_topic` | Topic template (string) or per-operation map (dict) | Required |
 | `field_mapping_config` | Field transformation configuration | `{}` (passthrough) |
+
+### `request_topic` Formats
+
+**String** — one topic for every operation:
+```yaml
+request_topic: "mycompany/identity/request/v1/{request_id}"
+```
+
+**Dict** — per-operation topics (operations not listed return `None` with a warning):
+```yaml
+request_topic:
+  user_profile: "mycompany/identity/user-profile/request/v1/{request_id}"
+  search_users: "mycompany/identity/search-users/request/v1/{request_id}"
+  employee_data: "mycompany/identity/employee-data/request/v1/{request_id}"
+```
+
+Available operation keys: `user_profile`, `search_users`, `employee_data`, `employee_profile`, `time_off`, `profile_picture`.
 
 ## Field Mapping Guide
 
 The field mapping engine transforms source data through a three-phase pipeline:
 
 ```
-Source Data → [1. Field Mapping] → [2. Exclusion] → [3. Renaming] → Output
-                                ↑
-                    [Computed Fields]
+Source Data -> [1. Field Mapping] -> [2. Exclusion] -> [3. Renaming] -> Output
+                                  ^
+                      [Computed Fields]
 ```
 
 ### Phase 1: field_mapping
@@ -213,8 +159,8 @@ Rename source fields to canonical names:
 
 ```yaml
 field_mapping:
-  emp_email: "workEmail"       # "emp_email" in source → "workEmail" in output
-  position: "jobTitle"         # "position" in source → "jobTitle" in output
+  emp_email: "workEmail"       # "emp_email" in source -> "workEmail" in output
+  position: "jobTitle"         # "position" in source -> "jobTitle" in output
 ```
 
 ### Computed Fields
@@ -353,3 +299,6 @@ pytest tests/ -v
 pytest tests/ --cov=sam_event_mesh_identity_provider --cov-report=term-missing
 ```
 
+## License
+
+Apache License 2.0

--- a/sam-event-mesh-identity-provider/config.yaml
+++ b/sam-event-mesh-identity-provider/config.yaml
@@ -21,6 +21,11 @@ identity_service: # Or people_service:
   # The key in 'auth_claims' used to look up the user (e.g., 'email', 'id', 'username')
   lookup_key: "email"
 
+  # The key name used in the request payload sent to the backend for user_profile lookups.
+  # Defaults to the value of lookup_key.
+  # Example: lookup_key is "email" (read from auth_claims), but the backend expects {"userId": "..."}
+  payload_key: "email"
+
   # Cache TTL in seconds. Set to 0 to disable caching.
   cache_ttl_seconds: 3600
 

--- a/sam-event-mesh-identity-provider/config.yaml
+++ b/sam-event-mesh-identity-provider/config.yaml
@@ -30,6 +30,12 @@ identity_service: # Or people_service:
   # Response topic prefix for the request-response session.
   response_topic_prefix: "sam/identity-provider/response"
 
+  # Key in the message user properties where the reply topic is stored.
+  user_properties_reply_topic_key: "replyTopic"
+
+  # Expression used by the broker to insert the response topic into the request.
+  response_topic_insertion_expression: "replyTopic"
+
   # --- Request Topic ---
   # Templates support {request_id} and payload field placeholders.
   #

--- a/sam-event-mesh-identity-provider/config.yaml
+++ b/sam-event-mesh-identity-provider/config.yaml
@@ -1,6 +1,5 @@
 # Plugin Metadata:
 # Name: sam-event-mesh-identity-provider
-# Version: 0.1.0
 # Description: Generic identity and employee service via Solace Event Mesh request-response
 # Author: SolaceLabs <solacelabs@solace.com>
 
@@ -28,34 +27,24 @@ identity_service: # Or people_service:
   # Default request expiry in milliseconds for all operations.
   request_expiry_ms: 120000
 
-  # Response topic prefix for the request-response session correlation.
+  # Response topic prefix for the request-response session.
   response_topic_prefix: "sam/identity-provider/response"
 
-  # --- Operation Topics ---
-  # Each operation requires both a request_topic and a response_topic.
+  # --- Request Topic ---
   # Templates support {request_id} and payload field placeholders.
   #
-  # Only operations listed here are active. If an operation is omitted,
-  # the corresponding method will return None with a warning log.
-  operations:
-    user_profile:
-      request_topic: "company/identity/user-profile/request/v1/{request_id}"
-      response_topic: "company/identity/user-profile/response/v1/"
-    search_users:
-      request_topic: "company/identity/search-users/request/v1/{request_id}"
-      response_topic: "company/identity/search-users/response/v1/"
-    employee_data:
-      request_topic: "company/identity/employee-data/request/v1/{request_id}"
-      response_topic: "company/identity/employee-data/response/v1/"
-    employee_profile:
-      request_topic: "company/identity/employee-profile/request/v1/{request_id}"
-      response_topic: "company/identity/employee-profile/response/v1/"
-    time_off:
-      request_topic: "company/identity/time-off/request/v1/{request_id}"
-      response_topic: "company/identity/time-off/response/v1/"
-    profile_picture:
-      request_topic: "company/identity/profile-picture/request/v1/{request_id}"
-      response_topic: "company/identity/profile-picture/response/v1/"
+  # String form — the same topic is used for every operation:
+  #   request_topic: "company/identity/request/v1/{request_id}"
+  #
+  # Dict form — each operation gets its own topic.
+  # Operations not listed here will return None with a warning log.
+  request_topic:
+    user_profile: "company/identity/user-profile/request/v1/{request_id}"
+    search_users: "company/identity/search-users/request/v1/{request_id}"
+    employee_data: "company/identity/employee-data/request/v1/{request_id}"
+    employee_profile: "company/identity/employee-profile/request/v1/{request_id}"
+    time_off: "company/identity/time-off/request/v1/{request_id}"
+    profile_picture: "company/identity/profile-picture/request/v1/{request_id}"
 
   # --- Field Mapping Configuration ---
   # Controls how source data from the backend is transformed before being returned.

--- a/sam-event-mesh-identity-provider/config.yaml
+++ b/sam-event-mesh-identity-provider/config.yaml
@@ -1,0 +1,88 @@
+# Plugin Metadata:
+# Name: sam-event-mesh-identity-provider
+# Version: 0.1.0
+# Description: Generic identity and employee service via Solace Event Mesh request-response
+# Author: SolaceLabs <solacelabs@solace.com>
+
+# This plugin can be used as either an identity_service (for gateway identity enrichment)
+# or a people_service (for agent employee queries).
+identity_service: # Or people_service:
+  # The 'type' must match the entry point key in the plugin's pyproject.toml
+  type: "event-mesh-identity-provider"
+
+  # --- Solace Broker Connection ---
+  dev_mode: ${SOLACE_DEV_MODE, false}
+  broker_url: "${IDENTITY_BROKER_URL}"
+  broker_vpn: "${IDENTITY_BROKER_VPN}"
+  broker_username: "${IDENTITY_BROKER_USERNAME}"
+  broker_password: "${IDENTITY_BROKER_PASSWORD}"
+
+  # --- General Settings ---
+
+  # The key in 'auth_claims' used to look up the user (e.g., 'email', 'id', 'username')
+  lookup_key: "email"
+
+  # Cache TTL in seconds. Set to 0 to disable caching.
+  cache_ttl_seconds: 3600
+
+  # Default request expiry in milliseconds for all operations.
+  request_expiry_ms: 120000
+
+  # Response topic prefix for the request-response session correlation.
+  response_topic_prefix: "sam/identity-provider/response"
+
+  # --- Operation Topics ---
+  # Each operation requires both a request_topic and a response_topic.
+  # Templates support {request_id} and payload field placeholders.
+  #
+  # Only operations listed here are active. If an operation is omitted,
+  # the corresponding method will return None with a warning log.
+  operations:
+    user_profile:
+      request_topic: "company/identity/user-profile/request/v1/{request_id}"
+      response_topic: "company/identity/user-profile/response/v1/"
+    search_users:
+      request_topic: "company/identity/search-users/request/v1/{request_id}"
+      response_topic: "company/identity/search-users/response/v1/"
+    employee_data:
+      request_topic: "company/identity/employee-data/request/v1/{request_id}"
+      response_topic: "company/identity/employee-data/response/v1/"
+    employee_profile:
+      request_topic: "company/identity/employee-profile/request/v1/{request_id}"
+      response_topic: "company/identity/employee-profile/response/v1/"
+    time_off:
+      request_topic: "company/identity/time-off/request/v1/{request_id}"
+      response_topic: "company/identity/time-off/response/v1/"
+    profile_picture:
+      request_topic: "company/identity/profile-picture/request/v1/{request_id}"
+      response_topic: "company/identity/profile-picture/response/v1/"
+
+  # --- Field Mapping Configuration ---
+  # Controls how source data from the backend is transformed before being returned.
+  # If omitted or empty, source fields pass through unchanged.
+  field_mapping_config:
+
+    # Phase 1: Map source field names to canonical field names.
+    # Only needed when the source system uses different field names.
+    # Example: { "emp_email": "workEmail", "title": "jobTitle" }
+    field_mapping: {}
+
+    # Computed fields: derive a field value from multiple source fields.
+    # Useful when displayName must be built from firstName + lastName.
+    # Each entry: { target: "displayName", source_fields: ["firstName", "lastName"], separator: " " }
+    # Or with a template: { target: "displayName", source_fields: [...], template: "{firstName} {lastName}" }
+    computed_fields: []
+
+    # Phase 2: List of field names to exclude from the output.
+    # Example: ["mobilePhone", "hireDate"]
+    exclusion_list: []
+
+    # Phase 3: Rename fields in the final output.
+    # Applied after field_mapping and exclusion_list.
+    # Example: { "supervisorId": "managerId", "workEmail": "email" }
+    rename_mapping: {}
+
+    # Whether to pass through source fields that have no entry in field_mapping.
+    # If true (default), unmapped fields appear in the output as-is.
+    # If false, only explicitly mapped fields and computed fields appear.
+    pass_through_unmapped: true

--- a/sam-event-mesh-identity-provider/pyproject.toml
+++ b/sam-event-mesh-identity-provider/pyproject.toml
@@ -1,0 +1,66 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.sam_event_mesh_identity_provider.metadata]
+type = "service"
+
+[project]
+name = "sam_event_mesh_identity_provider"
+version = "0.1.0"
+authors = [
+  { name="SolaceLabs", email="solacelabs@solace.com" },
+]
+description = "A generic identity and employee service provider that communicates with backend systems via Solace Event Mesh request-response."
+readme = "README.md"
+license = { text = "Apache License 2.0" }
+requires-python = ">=3.10.16,<3.14"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "pandas",
+]
+
+[project.urls]
+Homepage = "https://github.com/SolaceLabs/solace-agent-mesh"
+Documentation = "https://solacelabs.github.io/solace-agent-mesh/"
+Repository = "https://github.com/SolaceLabs/solace-agent-mesh-core-plugins"
+Issues = "https://github.com/SolaceLabs/solace-agent-mesh-core-plugins/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/sam_event_mesh_identity_provider"]
+src-path = "src"
+
+[tool.hatch.build.targets.wheel.force-include]
+"config.yaml" = "sam_event_mesh_identity_provider/config.yaml"
+"README.md" = "sam_event_mesh_identity_provider/README.md"
+"pyproject.toml" = "sam_event_mesh_identity_provider/pyproject.toml"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+addopts = "--tb=short --strict-markers --disable-warnings -p pytest_asyncio"
+markers = []
+
+[tool.hatch.envs.hatch-test]
+dependencies = [
+  "pytest-asyncio",
+  "pytest>=8.0.0",
+  "pytest-mock>=3.0.0",
+  "pytest-cov>=4.0.0",
+  "pytest-json-ctrf>=0.1.0",
+  "pytest-xdist>=3.5.0",
+  "solace-agent-mesh>=1.1.0,<2.0.0",
+  "sam-test-infrastructure @ git+https://github.com/SolaceLabs/solace-agent-mesh#subdirectory=tests/sam-test-infrastructure",
+]
+
+[project.entry-points."solace_agent_mesh.plugins"]
+event-mesh-identity-provider = "sam_event_mesh_identity_provider:info"

--- a/sam-event-mesh-identity-provider/sonar-project.properties
+++ b/sam-event-mesh-identity-provider/sonar-project.properties
@@ -1,0 +1,35 @@
+# SonarQube Configuration for sam-event-mesh-identity-provider
+sonar.projectKey=SolaceLabs_sam-event-mesh-identity-provider
+sonar.projectName=sam-event-mesh-identity-provider
+
+# Source and Test Directories
+sonar.sources=src/
+sonar.tests=tests/
+
+# Python Configuration
+sonar.python.version=3.10,3.11,3.12,3.13
+
+# Coverage Configuration
+sonar.python.coverage.reportPaths=**/coverage.xml
+
+# Source Encoding
+sonar.sourceEncoding=UTF-8
+
+# Exclusions
+sonar.exclusions=\
+  **/__pycache__/**,\
+  **/dist/**,\
+  **/.hatch/**,\
+  **/build/**,\
+  **/*.egg-info/**,\
+  **/tests/**
+
+# Duplication Exclusions
+sonar.cpd.exclusions=\
+  **/tests/**
+
+# Test Inclusions
+sonar.test.inclusions=\
+  **/tests/**/*.py,\
+  **/test_*.py,\
+  **/*_test.py

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/__init__.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/__init__.py
@@ -1,0 +1,4 @@
+info = {
+    "class_path": "sam_event_mesh_identity_provider.provider.EventMeshIdentityProvider",
+    "description": "Generic identity and employee service provider that communicates with backend systems via Solace Event Mesh request-response.",
+}

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/field_mapper.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/field_mapper.py
@@ -39,6 +39,27 @@ class FieldMapper:
             return None
 
         # Phase 1: Apply field_mapping (source -> canonical)
+        canonical = self._apply_field_mapping(source)
+
+        # Apply computed fields
+        self._apply_computed_fields(source, canonical)
+
+        # Phase 2: Apply exclusion_list
+        self._apply_exclusions(canonical)
+
+        # Phase 3: Apply rename_mapping (canonical -> output)
+        return self._apply_rename_mapping(canonical)
+
+    def _apply_field_mapping(self, source: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Apply field mapping and pass through unmapped fields.
+
+        Args:
+            source: Raw record from the backend system.
+
+        Returns:
+            Dictionary with mapped fields.
+        """
         canonical: Dict[str, Any] = {}
         mapped_source_keys: set = set()
 
@@ -53,46 +74,112 @@ class FieldMapper:
                 if key not in mapped_source_keys and key not in canonical:
                     canonical[key] = value
 
-        # Apply computed fields
+        return canonical
+
+    def _apply_computed_fields(self, source: Dict[str, Any], canonical: Dict[str, Any]) -> None:
+        """
+        Apply computed fields to the canonical dictionary.
+
+        Args:
+            source: Raw record from the backend system.
+            canonical: Dictionary to add computed fields to (modified in place).
+        """
         for computed in self.computed_fields:
             target = computed.get("target")
-            source_fields = computed.get("source_fields", [])
-            separator = computed.get("separator", " ")
-            template = computed.get("template")
-
             if not target:
                 continue
 
-            if template:
-                try:
-                    canonical[target] = template.format(**source)
-                except KeyError:
-                    parts = [
-                        str(source.get(f, "")).strip()
-                        for f in source_fields
-                        if source.get(f)
-                    ]
-                    if parts:
-                        canonical[target] = separator.join(parts)
-            else:
-                parts = [
-                    str(source.get(f, "")).strip()
-                    for f in source_fields
-                    if source.get(f)
-                ]
-                if parts:
-                    canonical[target] = separator.join(parts)
+            computed_value = self._compute_field_value(source, computed)
+            if computed_value is not None:
+                canonical[target] = computed_value
 
-        # Phase 2: Apply exclusion_list
+    def _compute_field_value(self, source: Dict[str, Any], computed: Dict[str, Any]) -> Optional[str]:
+        """
+        Compute a single field value using template or source fields.
+
+        Args:
+            source: Raw record from the backend system.
+            computed: Computed field configuration.
+
+        Returns:
+            Computed field value, or None if it cannot be computed.
+        """
+        template = computed.get("template")
+        
+        if template:
+            return self._compute_from_template(source, computed, template)
+        
+        return self._compute_from_source_fields(source, computed)
+
+    def _compute_from_template(
+        self, source: Dict[str, Any], computed: Dict[str, Any], template: str
+    ) -> Optional[str]:
+        """
+        Compute field value using a template string.
+
+        Args:
+            source: Raw record from the backend system.
+            computed: Computed field configuration.
+            template: Template string with placeholders.
+
+        Returns:
+            Formatted string, or fallback to source fields if template fails.
+        """
+        try:
+            return template.format(**source)
+        except KeyError:
+            # Fallback to source_fields if template fails
+            return self._compute_from_source_fields(source, computed)
+
+    def _compute_from_source_fields(self, source: Dict[str, Any], computed: Dict[str, Any]) -> Optional[str]:
+        """
+        Compute field value by joining source fields.
+
+        Args:
+            source: Raw record from the backend system.
+            computed: Computed field configuration.
+
+        Returns:
+            Joined string from source fields, or None if no valid parts.
+        """
+        source_fields = computed.get("source_fields", [])
+        separator = computed.get("separator", " ")
+        
+        parts = [
+            str(source.get(f, "")).strip()
+            for f in source_fields
+            if source.get(f)
+        ]
+        
+        if parts:
+            return separator.join(parts)
+        
+        return None
+
+    def _apply_exclusions(self, canonical: Dict[str, Any]) -> None:
+        """
+        Remove excluded fields from the canonical dictionary.
+
+        Args:
+            canonical: Dictionary to remove fields from (modified in place).
+        """
         for excluded_field in self.exclusion_list:
             canonical.pop(excluded_field, None)
 
-        # Phase 3: Apply rename_mapping (canonical -> output)
+    def _apply_rename_mapping(self, canonical: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Apply rename mapping to create the final output dictionary.
+
+        Args:
+            canonical: Dictionary with canonical field names.
+
+        Returns:
+            Dictionary with renamed fields.
+        """
         output: Dict[str, Any] = {}
         for key, value in canonical.items():
             output_key = self.rename_mapping.get(key, key)
             output[output_key] = value
-
         return output
 
     def map_records(self, sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/field_mapper.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/field_mapper.py
@@ -18,18 +18,6 @@ class FieldMapper:
     composed from firstName + lastName).
     """
 
-    CANONICAL_FIELDS = {
-        "id",
-        "displayName",
-        "workEmail",
-        "jobTitle",
-        "department",
-        "location",
-        "supervisorId",
-        "hireDate",
-        "mobilePhone",
-    }
-
     def __init__(self, config: Dict[str, Any]):
         self.field_mapping: Dict[str, str] = config.get("field_mapping", {})
         self.exclusion_list: List[str] = config.get("exclusion_list", [])

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/field_mapper.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/field_mapper.py
@@ -1,0 +1,112 @@
+"""Configurable field mapping engine for transforming source data to canonical format."""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
+
+class FieldMapper:
+    """
+    Transforms source records to canonical output format using a three-phase pipeline:
+
+    1. field_mapping: rename source fields to canonical field names
+    2. exclusion_list: remove unwanted fields from the output
+    3. rename_mapping: rename fields to custom output names
+
+    Additionally supports computed_fields for derived values (e.g., displayName
+    composed from firstName + lastName).
+    """
+
+    CANONICAL_FIELDS = {
+        "id",
+        "displayName",
+        "workEmail",
+        "jobTitle",
+        "department",
+        "location",
+        "supervisorId",
+        "hireDate",
+        "mobilePhone",
+    }
+
+    def __init__(self, config: Dict[str, Any]):
+        self.field_mapping: Dict[str, str] = config.get("field_mapping", {})
+        self.exclusion_list: List[str] = config.get("exclusion_list", [])
+        self.rename_mapping: Dict[str, str] = config.get("rename_mapping", {})
+        self.computed_fields: List[Dict[str, Any]] = config.get("computed_fields", [])
+        self.pass_through_unmapped: bool = config.get("pass_through_unmapped", True)
+
+    def map_record(self, source: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """
+        Transforms a single source record through the three-phase pipeline.
+
+        Args:
+            source: Raw record from the backend system.
+
+        Returns:
+            Transformed record, or None if source is None/empty.
+        """
+        if not source:
+            return None
+
+        # Phase 1: Apply field_mapping (source -> canonical)
+        canonical: Dict[str, Any] = {}
+        mapped_source_keys: set = set()
+
+        for source_key, canonical_key in self.field_mapping.items():
+            if source_key in source:
+                canonical[canonical_key] = source[source_key]
+                mapped_source_keys.add(source_key)
+
+        # Pass through unmapped fields
+        if self.pass_through_unmapped:
+            for key, value in source.items():
+                if key not in mapped_source_keys and key not in canonical:
+                    canonical[key] = value
+
+        # Apply computed fields
+        for computed in self.computed_fields:
+            target = computed.get("target")
+            source_fields = computed.get("source_fields", [])
+            separator = computed.get("separator", " ")
+            template = computed.get("template")
+
+            if not target:
+                continue
+
+            if template:
+                try:
+                    canonical[target] = template.format(**source)
+                except KeyError:
+                    parts = [
+                        str(source.get(f, "")).strip()
+                        for f in source_fields
+                        if source.get(f)
+                    ]
+                    if parts:
+                        canonical[target] = separator.join(parts)
+            else:
+                parts = [
+                    str(source.get(f, "")).strip()
+                    for f in source_fields
+                    if source.get(f)
+                ]
+                if parts:
+                    canonical[target] = separator.join(parts)
+
+        # Phase 2: Apply exclusion_list
+        for excluded_field in self.exclusion_list:
+            canonical.pop(excluded_field, None)
+
+        # Phase 3: Apply rename_mapping (canonical -> output)
+        output: Dict[str, Any] = {}
+        for key, value in canonical.items():
+            output_key = self.rename_mapping.get(key, key)
+            output[output_key] = value
+
+        return output
+
+    def map_records(self, sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Transforms a list of source records. Filters out None results."""
+        return [r for r in (self.map_record(s) for s in sources) if r is not None]

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/provider.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/provider.py
@@ -24,11 +24,6 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
     allowing it to be used for gateway identity enrichment **and** agent employee
     queries.  All data transformation is driven by the YAML ``field_mapping_config``
     section, making this provider completely vendor-agnostic.
-
-    Only operations explicitly listed under the ``operations`` config key are
-    active.  Methods whose operation is not configured return ``None`` (or an
-    empty collection) with a warning log so that deployments can enable only
-    the subset of operations they need.
     """
 
     def __init__(
@@ -63,14 +58,6 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
             self.service.cleanup()
 
     # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
-    def _is_configured(self, operation: str) -> bool:
-        """Return True if *operation* is present in the operations config."""
-        return self.service.is_operation_configured(operation)
-
-    # ------------------------------------------------------------------
     # BaseIdentityService
     # ------------------------------------------------------------------
 
@@ -78,13 +65,6 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
         self, auth_claims: Dict[str, Any]
     ) -> Optional[Dict[str, Any]]:
         """Fetch a user profile via the event mesh using an auth claim."""
-        if not self._is_configured("user_profile"):
-            log.warning(
-                "%s 'user_profile' operation is not configured — returning None.",
-                self.log_identifier,
-            )
-            return None
-
         if not auth_claims or not self.lookup_key:
             log.warning(
                 "%s No auth claims provided for user profile lookup.",
@@ -143,13 +123,6 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
         self, query: str, limit: int = 10
     ) -> List[Dict[str, Any]]:
         """Search for users via the event mesh."""
-        if not self._is_configured("search_users"):
-            log.warning(
-                "%s 'search_users' operation is not configured — returning empty list.",
-                self.log_identifier,
-            )
-            return []
-
         if not query or len(query) < 2:
             return []
 
@@ -179,13 +152,6 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
 
     async def get_employee_dataframe(self) -> pd.DataFrame:
         """Return the entire employee directory as a DataFrame."""
-        if not self._is_configured("employee_data"):
-            log.warning(
-                "%s 'employee_data' operation is not configured — returning empty DataFrame.",
-                self.log_identifier,
-            )
-            return pd.DataFrame()
-
         cache_key = "employee_dataframe"
         if self.cache:
             cached = self.cache.get(cache_key)
@@ -213,13 +179,6 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
         self, employee_id: str
     ) -> Optional[Dict[str, Any]]:
         """Fetch a single employee profile via the event mesh."""
-        if not self._is_configured("employee_profile"):
-            log.warning(
-                "%s 'employee_profile' operation is not configured — returning None.",
-                self.log_identifier,
-            )
-            return None
-
         cache_key = f"employee_profile_{employee_id.lower()}"
         if self.cache:
             cached = self.cache.get(cache_key)
@@ -246,13 +205,6 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
         end_date: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Retrieve time-off entries for an employee via the event mesh."""
-        if not self._is_configured("time_off"):
-            log.warning(
-                "%s 'time_off' operation is not configured — returning empty list.",
-                self.log_identifier,
-            )
-            return []
-
         payload: Dict[str, Any] = {"employee_id": employee_id}
         if start_date:
             payload["start_date"] = start_date
@@ -271,13 +223,6 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
         self, employee_id: str
     ) -> Optional[str]:
         """Fetch an employee's profile picture (data URI) via the event mesh."""
-        if not self._is_configured("profile_picture"):
-            log.warning(
-                "%s 'profile_picture' operation is not configured — returning None.",
-                self.log_identifier,
-            )
-            return None
-
         cache_key = f"profile_picture_{employee_id.lower()}"
         if self.cache:
             cached = self.cache.get(cache_key)

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/provider.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/provider.py
@@ -55,15 +55,21 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
             raise
 
     def __del__(self):
-        if hasattr(self, "service"):
-            self.service.cleanup()
+        try:
+            service = getattr(self, "service", None)
+            if service is not None:
+                service.cleanup()
+        except Exception:
+            # __del__ must never raise; interpreter shutdown can tear down
+            # dependencies before this runs.
+            pass
 
     # ------------------------------------------------------------------
     # BaseIdentityService
     # ------------------------------------------------------------------
 
     async def get_user_profile(
-        self, auth_claims: Dict[str, Any]
+        self, auth_claims: Any
     ) -> Optional[Dict[str, Any]]:
         """Fetch a user profile via the event mesh using an auth claim."""
         if not auth_claims or not self.lookup_key:
@@ -73,11 +79,10 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
             )
             return None
 
-        # Support both attribute and dict access on auth_claims.
-        if hasattr(auth_claims, self.lookup_key):
-            lookup_value = getattr(auth_claims, self.lookup_key)
-        else:
+        if isinstance(auth_claims, dict):
             lookup_value = auth_claims.get(self.lookup_key)
+        else:
+            lookup_value = getattr(auth_claims, self.lookup_key, None)
 
         if not lookup_value:
             log.warning(
@@ -87,7 +92,8 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
             )
             return None
 
-        cache_key = f"user_profile_{lookup_value.lower()}"
+        lookup_str = str(lookup_value).lower()
+        cache_key = f"user_profile_{lookup_str}"
         if self.cache:
             cached = self.cache.get(cache_key)
             if cached:
@@ -113,7 +119,7 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
 
         # Ensure the id field is always present.
         if profile and "id" not in profile:
-            profile["id"] = lookup_value.lower()
+            profile["id"] = lookup_str
 
         if self.cache and profile:
             self.cache.set(cache_key, profile, ttl=self.cache_ttl)

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/provider.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/provider.py
@@ -36,6 +36,7 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
         super().__init__(config, component)
 
         self.lookup_key: str = self.config.get("lookup_key", "email")
+        self.payload_key: str = self.config.get("payload_key", self.lookup_key)
         self.field_mapper = FieldMapper(self.config.get("field_mapping_config", {}))
 
         try:
@@ -98,7 +99,7 @@ class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
                 return cached
 
         response = await self.service.send_request(
-            "user_profile", {self.lookup_key: lookup_value}
+            "user_profile", {self.payload_key: lookup_value}
         )
         if not response:
             log.warning(

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/provider.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/provider.py
@@ -1,0 +1,300 @@
+"""Generic Event Mesh Identity and Employee Service Provider."""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+from solace_agent_mesh.common.services.identity_service import BaseIdentityService
+from solace_agent_mesh.common.services.employee_service import BaseEmployeeService
+from solace_agent_mesh.common.sac.sam_component_base import SamComponentBase
+
+from .field_mapper import FieldMapper
+from .service import EventMeshService
+
+log = logging.getLogger(__name__)
+
+
+class EventMeshIdentityProvider(BaseIdentityService, BaseEmployeeService):
+    """
+    Generic identity and employee service that communicates with any backend
+    system via Solace Event Mesh request-response messaging.
+
+    Implements both :class:`BaseIdentityService` and :class:`BaseEmployeeService`,
+    allowing it to be used for gateway identity enrichment **and** agent employee
+    queries.  All data transformation is driven by the YAML ``field_mapping_config``
+    section, making this provider completely vendor-agnostic.
+
+    Only operations explicitly listed under the ``operations`` config key are
+    active.  Methods whose operation is not configured return ``None`` (or an
+    empty collection) with a warning log so that deployments can enable only
+    the subset of operations they need.
+    """
+
+    def __init__(
+        self,
+        config: Dict[str, Any],
+        component: Optional[SamComponentBase] = None,
+    ):
+        # BaseIdentityService.__init__ sets self.config, self.component,
+        # self.log_identifier, self.cache_ttl, self.cache
+        super().__init__(config, component)
+
+        self.lookup_key: str = self.config.get("lookup_key", "email")
+        self.field_mapper = FieldMapper(self.config.get("field_mapping_config", {}))
+
+        try:
+            self.service = EventMeshService(config, component)
+            log.info(
+                "%s Initialized. Lookup key: '%s'.",
+                self.log_identifier,
+                self.lookup_key,
+            )
+        except Exception as e:
+            log.exception(
+                "%s Failed to initialize EventMeshService: %s",
+                self.log_identifier,
+                e,
+            )
+            raise
+
+    def __del__(self):
+        if hasattr(self, "service"):
+            self.service.cleanup()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _is_configured(self, operation: str) -> bool:
+        """Return True if *operation* is present in the operations config."""
+        return self.service.is_operation_configured(operation)
+
+    # ------------------------------------------------------------------
+    # BaseIdentityService
+    # ------------------------------------------------------------------
+
+    async def get_user_profile(
+        self, auth_claims: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """Fetch a user profile via the event mesh using an auth claim."""
+        if not self._is_configured("user_profile"):
+            log.warning(
+                "%s 'user_profile' operation is not configured — returning None.",
+                self.log_identifier,
+            )
+            return None
+
+        if not auth_claims or not self.lookup_key:
+            log.warning(
+                "%s No auth claims provided for user profile lookup.",
+                self.log_identifier,
+            )
+            return None
+
+        # Support both attribute and dict access on auth_claims.
+        if hasattr(auth_claims, self.lookup_key):
+            lookup_value = getattr(auth_claims, self.lookup_key)
+        else:
+            lookup_value = auth_claims.get(self.lookup_key)
+
+        if not lookup_value:
+            log.warning(
+                "%s Lookup key '%s' not found in auth_claims.",
+                self.log_identifier,
+                self.lookup_key,
+            )
+            return None
+
+        cache_key = f"user_profile_{lookup_value.lower()}"
+        if self.cache:
+            cached = self.cache.get(cache_key)
+            if cached:
+                log.debug(
+                    "%s Cache hit for user profile '%s'.",
+                    self.log_identifier,
+                    lookup_value,
+                )
+                return cached
+
+        response = await self.service.send_request(
+            "user_profile", {self.lookup_key: lookup_value}
+        )
+        if not response:
+            log.warning(
+                "%s No profile found for '%s'.",
+                self.log_identifier,
+                lookup_value,
+            )
+            return None
+
+        profile = self.field_mapper.map_record(response)
+
+        # Ensure the id field is always present.
+        if profile and "id" not in profile:
+            profile["id"] = lookup_value.lower()
+
+        if self.cache and profile:
+            self.cache.set(cache_key, profile, ttl=self.cache_ttl)
+
+        return profile
+
+    async def search_users(
+        self, query: str, limit: int = 10
+    ) -> List[Dict[str, Any]]:
+        """Search for users via the event mesh."""
+        if not self._is_configured("search_users"):
+            log.warning(
+                "%s 'search_users' operation is not configured — returning empty list.",
+                self.log_identifier,
+            )
+            return []
+
+        if not query or len(query) < 2:
+            return []
+
+        cache_key = f"search_{query.lower()}_{limit}"
+        if self.cache:
+            cached = self.cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        response = await self.service.send_request(
+            "search_users", {"query": query, "limit": limit}
+        )
+        if not response:
+            return []
+
+        users = response if isinstance(response, list) else response.get("results", [])
+        results = self.field_mapper.map_records(users)
+
+        if self.cache:
+            self.cache.set(cache_key, results, ttl=min(self.cache_ttl, 60))
+
+        return results
+
+    # ------------------------------------------------------------------
+    # BaseEmployeeService
+    # ------------------------------------------------------------------
+
+    async def get_employee_dataframe(self) -> pd.DataFrame:
+        """Return the entire employee directory as a DataFrame."""
+        if not self._is_configured("employee_data"):
+            log.warning(
+                "%s 'employee_data' operation is not configured — returning empty DataFrame.",
+                self.log_identifier,
+            )
+            return pd.DataFrame()
+
+        cache_key = "employee_dataframe"
+        if self.cache:
+            cached = self.cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+        response = await self.service.send_request("employee_data", {})
+        if not response:
+            return pd.DataFrame()
+
+        employees = (
+            response
+            if isinstance(response, list)
+            else response.get("employees", [])
+        )
+        mapped = self.field_mapper.map_records(employees)
+        df = pd.DataFrame(mapped)
+
+        if self.cache:
+            self.cache.set(cache_key, df, ttl=self.cache_ttl)
+
+        return df
+
+    async def get_employee_profile(
+        self, employee_id: str
+    ) -> Optional[Dict[str, Any]]:
+        """Fetch a single employee profile via the event mesh."""
+        if not self._is_configured("employee_profile"):
+            log.warning(
+                "%s 'employee_profile' operation is not configured — returning None.",
+                self.log_identifier,
+            )
+            return None
+
+        cache_key = f"employee_profile_{employee_id.lower()}"
+        if self.cache:
+            cached = self.cache.get(cache_key)
+            if cached:
+                return cached
+
+        response = await self.service.send_request(
+            "employee_profile", {"employee_id": employee_id}
+        )
+        if not response:
+            return None
+
+        profile = self.field_mapper.map_record(response)
+
+        if self.cache and profile:
+            self.cache.set(cache_key, profile, ttl=self.cache_ttl)
+
+        return profile
+
+    async def get_time_off_data(
+        self,
+        employee_id: str,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Retrieve time-off entries for an employee via the event mesh."""
+        if not self._is_configured("time_off"):
+            log.warning(
+                "%s 'time_off' operation is not configured — returning empty list.",
+                self.log_identifier,
+            )
+            return []
+
+        payload: Dict[str, Any] = {"employee_id": employee_id}
+        if start_date:
+            payload["start_date"] = start_date
+        if end_date:
+            payload["end_date"] = end_date
+
+        response = await self.service.send_request("time_off", payload)
+        if not response:
+            return []
+
+        # Time-off data follows a fixed schema (start, end, type, amount)
+        # so field mapping is not applied.
+        return response if isinstance(response, list) else response.get("entries", [])
+
+    async def get_employee_profile_picture(
+        self, employee_id: str
+    ) -> Optional[str]:
+        """Fetch an employee's profile picture (data URI) via the event mesh."""
+        if not self._is_configured("profile_picture"):
+            log.warning(
+                "%s 'profile_picture' operation is not configured — returning None.",
+                self.log_identifier,
+            )
+            return None
+
+        cache_key = f"profile_picture_{employee_id.lower()}"
+        if self.cache:
+            cached = self.cache.get(cache_key)
+            if cached:
+                return cached
+
+        response = await self.service.send_request(
+            "profile_picture", {"employee_id": employee_id}
+        )
+        if not response:
+            return None
+
+        picture_uri = (
+            response if isinstance(response, str) else response.get("data_uri")
+        )
+
+        if self.cache and picture_uri:
+            self.cache.set(cache_key, picture_uri, ttl=self.cache_ttl)
+
+        return picture_uri

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/service.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/service.py
@@ -8,18 +8,28 @@ from solace_ai_connector.common.message import Message
 
 log = logging.getLogger(__name__)
 
+# All supported operation names.
+ALL_OPERATIONS = (
+    "user_profile",
+    "search_users",
+    "employee_data",
+    "employee_profile",
+    "time_off",
+    "profile_picture",
+)
+
 
 class EventMeshService:
     """
     Sends requests to backend systems via Solace Event Mesh and waits for
     responses.  A single request-response session is shared across all
-    operations; each operation is routed to its own configurable request
-    and response topic pair.
+    operations; each operation is routed to its own configurable topic.
 
-    Only operations explicitly listed under the ``operations`` config key are
-    available.  Calling :meth:`send_request` for an operation that is not
-    configured returns ``None`` with a warning log — this is by design so
-    that deployments can enable only the operations they need.
+    ``request_topic`` accepts two forms:
+
+    * **string** — the same topic template is used for every operation.
+    * **dict**   — maps operation names to their individual topic templates.
+      Operations missing from the dict will log a warning and return ``None``.
     """
 
     def __init__(self, config: Dict[str, Any], component):
@@ -42,7 +52,7 @@ class EventMeshService:
         self.broker_username = self._config.get("broker_username")
         self.broker_password = self._config.get("broker_password")
 
-        # Response topic prefix (used for session-level correlation)
+        # Response topic prefix
         self.response_topic_prefix = self._config.get(
             "response_topic_prefix", "sam/identity-provider/response"
         )
@@ -50,17 +60,25 @@ class EventMeshService:
         # Request expiry
         self.default_request_expiry_ms = self._config.get("request_expiry_ms", 120000)
 
-        # Operation topics — each entry must have request_topic and response_topic.
-        self.operations: Dict[str, Dict[str, str]] = self._config.get("operations", {})
+        # Build per-operation topic map from request_topic config.
+        raw = self._config.get("request_topic", {})
+        if isinstance(raw, str):
+            # Single topic string → use for every operation.
+            self.topic_map: Dict[str, str] = dict.fromkeys(ALL_OPERATIONS, raw)
+        elif isinstance(raw, dict):
+            self.topic_map = dict(raw)
+        else:
+            raise ValueError(
+                f"'request_topic' must be a string or dict, got {type(raw).__name__}."
+            )
 
         self._create_session()
 
         log.info(
-            "%s Initialized for broker '%s' with %d configured operations: %s",
+            "%s Initialized for broker '%s' with %d configured operations.",
             self.log_identifier,
             self.broker_url,
-            len(self.operations),
-            list(self.operations.keys()),
+            len(self.topic_map),
         )
 
     # ------------------------------------------------------------------
@@ -105,10 +123,6 @@ class EventMeshService:
     # Generic request / response
     # ------------------------------------------------------------------
 
-    def is_operation_configured(self, operation: str) -> bool:
-        """Check whether *operation* has been configured."""
-        return operation in self.operations
-
     async def send_request(
         self, operation: str, payload: Dict[str, Any]
     ) -> Optional[Any]:
@@ -116,32 +130,28 @@ class EventMeshService:
         Send a request for *operation* and return the response payload.
 
         Args:
-            operation: Operation name — must match a key under ``operations``
-                in the YAML configuration.
+            operation: Operation name (must match a key in ``topic_map``).
             payload: Request payload dict forwarded to the backend.
 
         Returns:
-            Parsed response payload, or ``None`` if the operation is not
-            configured or the request fails.
+            Parsed response payload, or ``None`` on failure.
         """
-        op_config = self.operations.get(operation)
-        if not op_config:
+        topic_template = self.topic_map.get(operation)
+        if not topic_template:
             log.warning(
-                "%s Operation '%s' is not configured. "
-                "Add it to the 'operations' section in your config to enable it. "
-                "Currently configured operations: %s",
+                "%s No request_topic configured for operation '%s'. "
+                "Available: %s",
                 self.log_identifier,
                 operation,
-                list(self.operations.keys()),
+                list(self.topic_map.keys()),
             )
             return None
 
-        request_topic_template = op_config.get("request_topic", "")
         request_id = str(uuid.uuid4())
 
         try:
             format_vars = {"request_id": request_id, **payload}
-            request_topic = request_topic_template.format(**format_vars)
+            request_topic = topic_template.format(**format_vars)
         except KeyError as e:
             log.error(
                 "%s Topic template for operation '%s' requires variable %s "

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/service.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/service.py
@@ -60,6 +60,14 @@ class EventMeshService:
         # Request expiry
         self.default_request_expiry_ms = self._config.get("request_expiry_ms", 120000)
 
+        # Reply-topic routing keys
+        self.user_properties_reply_topic_key = self._config.get(
+            "user_properties_reply_topic_key", "replyTopic"
+        )
+        self.response_topic_insertion_expression = self._config.get(
+            "response_topic_insertion_expression", "replyTopic"
+        )
+
         # Build per-operation topic map from request_topic config.
         raw = self._config.get("request_topic", {})
         if isinstance(raw, str):
@@ -100,6 +108,8 @@ class EventMeshService:
             "payload_format": "json",
             "response_topic_prefix": self.response_topic_prefix,
             "response_queue_prefix": self.response_topic_prefix,
+            "user_properties_reply_topic_key": self.user_properties_reply_topic_key,
+            "response_topic_insertion_expression": self.response_topic_insertion_expression,
         }
 
         try:

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/service.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/service.py
@@ -1,0 +1,200 @@
+"""Generic event mesh service for request-response communication via Solace broker."""
+
+import logging
+import uuid
+from typing import Any, Dict, Optional
+
+from solace_ai_connector.common.message import Message
+
+log = logging.getLogger(__name__)
+
+
+class EventMeshService:
+    """
+    Sends requests to backend systems via Solace Event Mesh and waits for
+    responses.  A single request-response session is shared across all
+    operations; each operation is routed to its own configurable request
+    and response topic pair.
+
+    Only operations explicitly listed under the ``operations`` config key are
+    available.  Calling :meth:`send_request` for an operation that is not
+    configured returns ``None`` with a warning log — this is by design so
+    that deployments can enable only the operations they need.
+    """
+
+    def __init__(self, config: Dict[str, Any], component):
+        if not config:
+            raise ValueError("EventMeshService requires a configuration dictionary.")
+        if not component:
+            raise ValueError(
+                "EventMeshService requires a SAM component reference for broker communication."
+            )
+
+        self._config = config
+        self.component = component
+        self.log_identifier = "[EventMeshService]"
+        self.session_id: Optional[str] = None
+
+        # Broker connection
+        self.dev_mode = self._config.get("dev_mode", False)
+        self.broker_url = self._config.get("broker_url")
+        self.broker_vpn = self._config.get("broker_vpn")
+        self.broker_username = self._config.get("broker_username")
+        self.broker_password = self._config.get("broker_password")
+
+        # Response topic prefix (used for session-level correlation)
+        self.response_topic_prefix = self._config.get(
+            "response_topic_prefix", "sam/identity-provider/response"
+        )
+
+        # Request expiry
+        self.default_request_expiry_ms = self._config.get("request_expiry_ms", 120000)
+
+        # Operation topics — each entry must have request_topic and response_topic.
+        self.operations: Dict[str, Dict[str, str]] = self._config.get("operations", {})
+
+        self._create_session()
+
+        log.info(
+            "%s Initialized for broker '%s' with %d configured operations: %s",
+            self.log_identifier,
+            self.broker_url,
+            len(self.operations),
+            list(self.operations.keys()),
+        )
+
+    # ------------------------------------------------------------------
+    # Session management
+    # ------------------------------------------------------------------
+
+    def _create_session(self):
+        """Creates a request-response session on the Solace broker."""
+        event_mesh_config = {
+            "broker_config": {
+                "dev_mode": self.dev_mode,
+                "broker_url": self.broker_url,
+                "broker_username": self.broker_username,
+                "broker_password": self.broker_password,
+                "broker_vpn": self.broker_vpn,
+            },
+            "request_expiry_ms": self.default_request_expiry_ms,
+            "payload_encoding": "utf-8",
+            "payload_format": "json",
+            "response_topic_prefix": self.response_topic_prefix,
+            "response_queue_prefix": self.response_topic_prefix,
+        }
+
+        try:
+            self.session_id = self.component.create_request_response_session(
+                session_config=event_mesh_config
+            )
+            log.info(
+                "%s Session created with ID: %s",
+                self.log_identifier,
+                self.session_id,
+            )
+        except Exception as e:
+            log.error(
+                "%s Failed to create request/response session: %s",
+                self.log_identifier,
+                e,
+            )
+            raise
+
+    # ------------------------------------------------------------------
+    # Generic request / response
+    # ------------------------------------------------------------------
+
+    def is_operation_configured(self, operation: str) -> bool:
+        """Check whether *operation* has been configured."""
+        return operation in self.operations
+
+    async def send_request(
+        self, operation: str, payload: Dict[str, Any]
+    ) -> Optional[Any]:
+        """
+        Send a request for *operation* and return the response payload.
+
+        Args:
+            operation: Operation name — must match a key under ``operations``
+                in the YAML configuration.
+            payload: Request payload dict forwarded to the backend.
+
+        Returns:
+            Parsed response payload, or ``None`` if the operation is not
+            configured or the request fails.
+        """
+        op_config = self.operations.get(operation)
+        if not op_config:
+            log.warning(
+                "%s Operation '%s' is not configured. "
+                "Add it to the 'operations' section in your config to enable it. "
+                "Currently configured operations: %s",
+                self.log_identifier,
+                operation,
+                list(self.operations.keys()),
+            )
+            return None
+
+        request_topic_template = op_config.get("request_topic", "")
+        request_id = str(uuid.uuid4())
+
+        try:
+            format_vars = {"request_id": request_id, **payload}
+            request_topic = request_topic_template.format(**format_vars)
+        except KeyError as e:
+            log.error(
+                "%s Topic template for operation '%s' requires variable %s "
+                "not found in payload.",
+                self.log_identifier,
+                operation,
+                e,
+            )
+            return None
+
+        log.info(
+            "%s Sending '%s' request (id: %s) to topic: %s",
+            self.log_identifier,
+            operation,
+            request_id,
+            request_topic,
+        )
+
+        try:
+            message = Message(payload=payload, topic=request_topic)
+            response_message: Message = (
+                await self.component.do_broker_request_response_async(
+                    message, session_id=self.session_id
+                )
+            )
+            response = response_message.get_payload()
+
+            log.info(
+                "%s Received response for '%s' request (id: %s)",
+                self.log_identifier,
+                operation,
+                request_id,
+            )
+            return response
+
+        except Exception as e:
+            log.exception(
+                "%s Failed '%s' request (id: %s): %s",
+                self.log_identifier,
+                operation,
+                request_id,
+                e,
+            )
+            return None
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def cleanup(self):
+        """Destroys the request-response session."""
+        log.info("%s Shutting down EventMeshService", self.log_identifier)
+        if self.session_id and self.component:
+            self.component.destroy_request_response_session(self.session_id)
+            self.session_id = None
+        log.info("%s Shutdown complete", self.log_identifier)

--- a/sam-event-mesh-identity-provider/tests/conftest.py
+++ b/sam-event-mesh-identity-provider/tests/conftest.py
@@ -27,7 +27,7 @@ def mock_component():
 
 @pytest.fixture
 def base_config():
-    """A minimal valid configuration dictionary."""
+    """A minimal valid configuration dictionary using per-operation topics."""
     return {
         "type": "event-mesh-identity-provider",
         "broker_url": "tcp://localhost:55555",
@@ -39,33 +39,21 @@ def base_config():
         "cache_ttl_seconds": 3600,
         "request_expiry_ms": 120000,
         "response_topic_prefix": "test/response",
-        "operations": {
-            "user_profile": {
-                "request_topic": "test/user-profile/{request_id}",
-            },
-            "search_users": {
-                "request_topic": "test/search-users/{request_id}",
-            },
-            "employee_data": {
-                "request_topic": "test/employee-data/{request_id}",
-            },
-            "employee_profile": {
-                "request_topic": "test/employee-profile/{request_id}",
-            },
-            "time_off": {
-                "request_topic": "test/time-off/{request_id}",
-            },
-            "profile_picture": {
-                "request_topic": "test/profile-picture/{request_id}",
-            },
+        "request_topic": {
+            "user_profile": "test/user-profile/{request_id}",
+            "search_users": "test/search-users/{request_id}",
+            "employee_data": "test/employee-data/{request_id}",
+            "employee_profile": "test/employee-profile/{request_id}",
+            "time_off": "test/time-off/{request_id}",
+            "profile_picture": "test/profile-picture/{request_id}",
         },
         "field_mapping_config": {},
     }
 
 
 @pytest.fixture
-def flat_config():
-    """Configuration using the legacy flat-topic format (backward compat)."""
+def string_topic_config():
+    """Configuration using a single string request_topic for all operations."""
     return {
         "type": "event-mesh-identity-provider",
         "broker_url": "tcp://localhost:55555",
@@ -75,48 +63,23 @@ def flat_config():
         "dev_mode": True,
         "lookup_key": "email",
         "cache_ttl_seconds": 3600,
-        "request_topic": "TI/AI/HRM/user/requested/v1/{request_id}",
-        "response_topic": "TI/AI/HRM/user/retrieved/v1/",
+        "request_topic": "company/identity/request/v1/{request_id}",
         "field_mapping_config": {},
     }
 
 
 @pytest.fixture
-def jde_field_mapping_config():
-    """JDE-specific field mapping configuration for backward compat testing."""
-    return {
-        "field_mapping": {
-            "email": "workEmail",
-            "positionTitle": "jobTitle",
-        },
-        "computed_fields": [
-            {
-                "target": "displayName",
-                "source_fields": ["userFirstName", "userMiddleName", "userSurname"],
-                "separator": " ",
-            },
-            {
-                "target": "id",
-                "source_fields": ["email"],
-                "separator": "",
-            },
-        ],
-        "pass_through_unmapped": True,
-    }
-
-
-@pytest.fixture
-def sample_jde_employee():
-    """A sample employee record as returned by JDE/SuccessFactor."""
+def sample_source_employee():
+    """A sample employee record as returned by a backend HR system."""
     return {
         "email": "jane.doe@company.com",
-        "userFirstName": "Jane",
-        "userMiddleName": "",
-        "userSurname": "Doe",
-        "positionTitle": "Senior Engineer",
+        "firstName": "Jane",
+        "middleName": "",
+        "lastName": "Doe",
+        "title": "Senior Engineer",
         "department": "Engineering",
         "location": "Toronto",
-        "manager": "mgr@company.com",
+        "managerId": "mgr@company.com",
         "managerName": "John Manager",
         "company": "Acme Corp",
         "costCenter": "CC100",

--- a/sam-event-mesh-identity-provider/tests/conftest.py
+++ b/sam-event-mesh-identity-provider/tests/conftest.py
@@ -1,0 +1,136 @@
+"""Shared test fixtures for the Event Mesh Identity Provider plugin."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from solace_agent_mesh.common.utils.in_memory_cache import InMemoryCache
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Clear the InMemoryCache singleton before each test to prevent leakage."""
+    cache = InMemoryCache()
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def mock_component():
+    """A mock SAM component with broker request-response capabilities."""
+    component = MagicMock()
+    component.create_request_response_session = MagicMock(return_value="test-session-id")
+    component.do_broker_request_response_async = AsyncMock()
+    component.destroy_request_response_session = MagicMock()
+    return component
+
+
+@pytest.fixture
+def base_config():
+    """A minimal valid configuration dictionary with all operations."""
+    return {
+        "type": "event-mesh-identity-provider",
+        "broker_url": "tcp://localhost:55555",
+        "broker_vpn": "default",
+        "broker_username": "user",
+        "broker_password": "pass",
+        "dev_mode": True,
+        "lookup_key": "email",
+        "cache_ttl_seconds": 3600,
+        "request_expiry_ms": 120000,
+        "response_topic_prefix": "test/response",
+        "operations": {
+            "user_profile": {
+                "request_topic": "test/user-profile/{request_id}",
+                "response_topic": "test/user-profile/response/",
+            },
+            "search_users": {
+                "request_topic": "test/search-users/{request_id}",
+                "response_topic": "test/search-users/response/",
+            },
+            "employee_data": {
+                "request_topic": "test/employee-data/{request_id}",
+                "response_topic": "test/employee-data/response/",
+            },
+            "employee_profile": {
+                "request_topic": "test/employee-profile/{request_id}",
+                "response_topic": "test/employee-profile/response/",
+            },
+            "time_off": {
+                "request_topic": "test/time-off/{request_id}",
+                "response_topic": "test/time-off/response/",
+            },
+            "profile_picture": {
+                "request_topic": "test/profile-picture/{request_id}",
+                "response_topic": "test/profile-picture/response/",
+            },
+        },
+        "field_mapping_config": {},
+    }
+
+
+@pytest.fixture
+def partial_config():
+    """Configuration with only user_profile operation configured."""
+    return {
+        "type": "event-mesh-identity-provider",
+        "broker_url": "tcp://localhost:55555",
+        "broker_vpn": "default",
+        "broker_username": "user",
+        "broker_password": "pass",
+        "dev_mode": True,
+        "lookup_key": "email",
+        "cache_ttl_seconds": 3600,
+        "request_expiry_ms": 120000,
+        "response_topic_prefix": "test/response",
+        "operations": {
+            "user_profile": {
+                "request_topic": "test/user-profile/{request_id}",
+                "response_topic": "test/user-profile/response/",
+            },
+        },
+        "field_mapping_config": {},
+    }
+
+
+@pytest.fixture
+def hr_field_mapping_config():
+    """Field mapping config for a typical HR system with non-canonical field names."""
+    return {
+        "field_mapping": {
+            "email": "workEmail",
+            "positionTitle": "jobTitle",
+        },
+        "computed_fields": [
+            {
+                "target": "displayName",
+                "source_fields": ["userFirstName", "userMiddleName", "userSurname"],
+                "separator": " ",
+            },
+            {
+                "target": "id",
+                "source_fields": ["email"],
+                "separator": "",
+            },
+        ],
+        "pass_through_unmapped": True,
+    }
+
+
+@pytest.fixture
+def sample_hr_employee():
+    """A sample employee record from an HR system with non-canonical field names."""
+    return {
+        "email": "jane.doe@company.com",
+        "userFirstName": "Jane",
+        "userMiddleName": "",
+        "userSurname": "Doe",
+        "positionTitle": "Senior Engineer",
+        "department": "Engineering",
+        "location": "Toronto",
+        "manager": "mgr@company.com",
+        "managerName": "John Manager",
+        "company": "Acme Corp",
+        "costCenter": "CC100",
+        "country": "Canada",
+    }

--- a/sam-event-mesh-identity-provider/tests/conftest.py
+++ b/sam-event-mesh-identity-provider/tests/conftest.py
@@ -27,7 +27,7 @@ def mock_component():
 
 @pytest.fixture
 def base_config():
-    """A minimal valid configuration dictionary with all operations."""
+    """A minimal valid configuration dictionary."""
     return {
         "type": "event-mesh-identity-provider",
         "broker_url": "tcp://localhost:55555",
@@ -42,27 +42,21 @@ def base_config():
         "operations": {
             "user_profile": {
                 "request_topic": "test/user-profile/{request_id}",
-                "response_topic": "test/user-profile/response/",
             },
             "search_users": {
                 "request_topic": "test/search-users/{request_id}",
-                "response_topic": "test/search-users/response/",
             },
             "employee_data": {
                 "request_topic": "test/employee-data/{request_id}",
-                "response_topic": "test/employee-data/response/",
             },
             "employee_profile": {
                 "request_topic": "test/employee-profile/{request_id}",
-                "response_topic": "test/employee-profile/response/",
             },
             "time_off": {
                 "request_topic": "test/time-off/{request_id}",
-                "response_topic": "test/time-off/response/",
             },
             "profile_picture": {
                 "request_topic": "test/profile-picture/{request_id}",
-                "response_topic": "test/profile-picture/response/",
             },
         },
         "field_mapping_config": {},
@@ -70,8 +64,8 @@ def base_config():
 
 
 @pytest.fixture
-def partial_config():
-    """Configuration with only user_profile operation configured."""
+def flat_config():
+    """Configuration using the legacy flat-topic format (backward compat)."""
     return {
         "type": "event-mesh-identity-provider",
         "broker_url": "tcp://localhost:55555",
@@ -81,21 +75,15 @@ def partial_config():
         "dev_mode": True,
         "lookup_key": "email",
         "cache_ttl_seconds": 3600,
-        "request_expiry_ms": 120000,
-        "response_topic_prefix": "test/response",
-        "operations": {
-            "user_profile": {
-                "request_topic": "test/user-profile/{request_id}",
-                "response_topic": "test/user-profile/response/",
-            },
-        },
+        "request_topic": "TI/AI/HRM/user/requested/v1/{request_id}",
+        "response_topic": "TI/AI/HRM/user/retrieved/v1/",
         "field_mapping_config": {},
     }
 
 
 @pytest.fixture
-def hr_field_mapping_config():
-    """Field mapping config for a typical HR system with non-canonical field names."""
+def jde_field_mapping_config():
+    """JDE-specific field mapping configuration for backward compat testing."""
     return {
         "field_mapping": {
             "email": "workEmail",
@@ -118,8 +106,8 @@ def hr_field_mapping_config():
 
 
 @pytest.fixture
-def sample_hr_employee():
-    """A sample employee record from an HR system with non-canonical field names."""
+def sample_jde_employee():
+    """A sample employee record as returned by JDE/SuccessFactor."""
     return {
         "email": "jane.doe@company.com",
         "userFirstName": "Jane",

--- a/sam-event-mesh-identity-provider/tests/unit/test_field_mapper.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_field_mapper.py
@@ -1,0 +1,247 @@
+"""Unit tests for the FieldMapper class."""
+
+import pytest
+
+from sam_event_mesh_identity_provider.field_mapper import FieldMapper
+
+
+class TestFieldMapperPassthrough:
+    """Tests for zero-config passthrough behavior."""
+
+    def test_passthrough_no_config(self):
+        """With empty config, source fields pass through unchanged."""
+        mapper = FieldMapper({})
+        source = {"id": "123", "workEmail": "a@b.com", "jobTitle": "Dev"}
+        result = mapper.map_record(source)
+        assert result == source
+
+    def test_passthrough_preserves_all_fields(self):
+        """All source fields appear in output when pass_through_unmapped is true."""
+        mapper = FieldMapper({"pass_through_unmapped": True})
+        source = {"custom1": "val1", "custom2": "val2", "nested": {"a": 1}}
+        result = mapper.map_record(source)
+        assert result == source
+
+
+class TestFieldMapperMapping:
+    """Tests for field_mapping (Phase 1)."""
+
+    def test_basic_field_mapping(self):
+        """Source fields are renamed according to field_mapping."""
+        mapper = FieldMapper({
+            "field_mapping": {"emp_email": "workEmail", "emp_id": "id"},
+            "pass_through_unmapped": False,
+        })
+        source = {"emp_email": "a@b.com", "emp_id": "123", "extra": "data"}
+        result = mapper.map_record(source)
+        assert result == {"workEmail": "a@b.com", "id": "123"}
+
+    def test_mapped_field_not_in_source(self):
+        """Mapping entries for missing source fields are silently skipped."""
+        mapper = FieldMapper({
+            "field_mapping": {"missing_key": "workEmail"},
+            "pass_through_unmapped": False,
+        })
+        source = {"other_field": "value"}
+        result = mapper.map_record(source)
+        assert result == {}
+
+    def test_mapping_with_passthrough(self):
+        """Mapped and unmapped fields both appear when pass_through_unmapped is true."""
+        mapper = FieldMapper({
+            "field_mapping": {"emp_email": "workEmail"},
+            "pass_through_unmapped": True,
+        })
+        source = {"emp_email": "a@b.com", "department": "Eng"}
+        result = mapper.map_record(source)
+        assert result == {"workEmail": "a@b.com", "department": "Eng"}
+
+
+class TestFieldMapperExclusion:
+    """Tests for exclusion_list (Phase 2)."""
+
+    def test_exclusion_list_removes_fields(self):
+        """Fields in exclusion_list are removed from output."""
+        mapper = FieldMapper({"exclusion_list": ["mobilePhone", "hireDate"]})
+        source = {"id": "1", "mobilePhone": "555", "hireDate": "2020-01-01", "name": "A"}
+        result = mapper.map_record(source)
+        assert "mobilePhone" not in result
+        assert "hireDate" not in result
+        assert result["id"] == "1"
+        assert result["name"] == "A"
+
+    def test_exclusion_of_nonexistent_field(self):
+        """Excluding a field that doesn't exist in source doesn't error."""
+        mapper = FieldMapper({"exclusion_list": ["nonexistent"]})
+        source = {"id": "1"}
+        result = mapper.map_record(source)
+        assert result == {"id": "1"}
+
+
+class TestFieldMapperRenaming:
+    """Tests for rename_mapping (Phase 3)."""
+
+    def test_rename_mapping(self):
+        """Canonical fields are renamed in the output."""
+        mapper = FieldMapper({
+            "rename_mapping": {"supervisorId": "managerId", "workEmail": "email"},
+        })
+        source = {"supervisorId": "mgr1", "workEmail": "a@b.com", "id": "1"}
+        result = mapper.map_record(source)
+        assert result == {"managerId": "mgr1", "email": "a@b.com", "id": "1"}
+
+    def test_rename_only_affects_matching_keys(self):
+        """Fields not in rename_mapping keep their original names."""
+        mapper = FieldMapper({"rename_mapping": {"workEmail": "email"}})
+        source = {"workEmail": "a@b.com", "id": "1"}
+        result = mapper.map_record(source)
+        assert result == {"email": "a@b.com", "id": "1"}
+
+
+class TestFieldMapperComputedFields:
+    """Tests for computed_fields."""
+
+    def test_computed_field_concatenation(self):
+        """Computed field concatenates source fields with separator."""
+        mapper = FieldMapper({
+            "computed_fields": [
+                {
+                    "target": "displayName",
+                    "source_fields": ["firstName", "lastName"],
+                    "separator": " ",
+                }
+            ],
+            "pass_through_unmapped": False,
+        })
+        source = {"firstName": "Jane", "lastName": "Doe"}
+        result = mapper.map_record(source)
+        assert result["displayName"] == "Jane Doe"
+
+    def test_computed_field_skips_empty_parts(self):
+        """Empty source fields are skipped during concatenation."""
+        mapper = FieldMapper({
+            "computed_fields": [
+                {
+                    "target": "displayName",
+                    "source_fields": ["firstName", "middleName", "lastName"],
+                    "separator": " ",
+                }
+            ],
+            "pass_through_unmapped": False,
+        })
+        source = {"firstName": "Jane", "middleName": "", "lastName": "Doe"}
+        result = mapper.map_record(source)
+        assert result["displayName"] == "Jane Doe"
+
+    def test_computed_field_with_template(self):
+        """Template-based computed field uses format string."""
+        mapper = FieldMapper({
+            "computed_fields": [
+                {
+                    "target": "displayName",
+                    "source_fields": ["firstName", "lastName"],
+                    "template": "{firstName} {lastName}",
+                }
+            ],
+            "pass_through_unmapped": False,
+        })
+        source = {"firstName": "Jane", "lastName": "Doe"}
+        result = mapper.map_record(source)
+        assert result["displayName"] == "Jane Doe"
+
+    def test_computed_field_template_fallback(self):
+        """When template format fails, falls back to concatenation."""
+        mapper = FieldMapper({
+            "computed_fields": [
+                {
+                    "target": "displayName",
+                    "source_fields": ["firstName", "lastName"],
+                    "template": "{firstName} {missingKey}",
+                    "separator": " ",
+                }
+            ],
+            "pass_through_unmapped": False,
+        })
+        source = {"firstName": "Jane", "lastName": "Doe"}
+        result = mapper.map_record(source)
+        assert result["displayName"] == "Jane Doe"
+
+    def test_computed_field_no_target(self):
+        """Computed field with no target is skipped."""
+        mapper = FieldMapper({
+            "computed_fields": [
+                {"source_fields": ["firstName", "lastName"], "separator": " "}
+            ],
+            "pass_through_unmapped": False,
+        })
+        source = {"firstName": "Jane", "lastName": "Doe"}
+        result = mapper.map_record(source)
+        assert result == {}
+
+
+class TestFieldMapperFullPipeline:
+    """Tests for the complete three-phase pipeline."""
+
+    def test_full_pipeline(self):
+        """All three phases applied in sequence: mapping, exclusion, renaming."""
+        mapper = FieldMapper({
+            "field_mapping": {"emp_title": "jobTitle", "emp_email": "workEmail"},
+            "exclusion_list": ["workEmail"],
+            "rename_mapping": {"jobTitle": "title"},
+            "pass_through_unmapped": False,
+        })
+        source = {"emp_title": "Engineer", "emp_email": "a@b.com"}
+        result = mapper.map_record(source)
+        # workEmail is excluded, jobTitle renamed to title
+        assert result == {"title": "Engineer"}
+
+    def test_hr_system_mapping(self, hr_field_mapping_config, sample_hr_employee):
+        """Verify HR system mapping produces the expected canonical output."""
+        mapper = FieldMapper(hr_field_mapping_config)
+        result = mapper.map_record(sample_hr_employee)
+
+        assert result["displayName"] == "Jane Doe"
+        assert result["id"] == "jane.doe@company.com"
+        assert result["workEmail"] == "jane.doe@company.com"
+        assert result["jobTitle"] == "Senior Engineer"
+        assert result["department"] == "Engineering"
+        assert result["location"] == "Toronto"
+        assert result["manager"] == "mgr@company.com"
+
+
+class TestFieldMapperEdgeCases:
+    """Tests for edge cases."""
+
+    def test_none_input(self):
+        """Returns None when source is None."""
+        mapper = FieldMapper({})
+        assert mapper.map_record(None) is None
+
+    def test_empty_dict_input(self):
+        """Returns None when source is empty dict."""
+        mapper = FieldMapper({})
+        assert mapper.map_record({}) is None
+
+    def test_map_records_list(self):
+        """map_records processes a list and filters out None results."""
+        mapper = FieldMapper({"pass_through_unmapped": True})
+        sources = [
+            {"id": "1", "name": "Alice"},
+            {},
+            {"id": "2", "name": "Bob"},
+            None,
+        ]
+        results = mapper.map_records(sources)
+        assert len(results) == 2
+        assert results[0]["id"] == "1"
+        assert results[1]["id"] == "2"
+
+    def test_pass_through_unmapped_false(self):
+        """Only mapped fields appear when pass_through_unmapped is false."""
+        mapper = FieldMapper({
+            "field_mapping": {"name": "displayName"},
+            "pass_through_unmapped": False,
+        })
+        source = {"name": "Jane", "extra_field": "value", "another": "data"}
+        result = mapper.map_record(source)
+        assert result == {"displayName": "Jane"}

--- a/sam-event-mesh-identity-provider/tests/unit/test_field_mapper.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_field_mapper.py
@@ -195,10 +195,39 @@ class TestFieldMapperFullPipeline:
         # workEmail is excluded, jobTitle renamed to title
         assert result == {"title": "Engineer"}
 
-    def test_jde_mapping(self, jde_field_mapping_config, sample_jde_employee):
-        """Verify JDE-specific mapping produces the expected canonical output."""
-        mapper = FieldMapper(jde_field_mapping_config)
-        result = mapper.map_record(sample_jde_employee)
+    def test_hr_system_mapping(self):
+        """Verify a realistic HR system mapping with computed fields and renaming."""
+        config = {
+            "field_mapping": {
+                "emp_email": "workEmail",
+                "position": "jobTitle",
+            },
+            "computed_fields": [
+                {
+                    "target": "displayName",
+                    "source_fields": ["firstName", "middleName", "lastName"],
+                    "separator": " ",
+                },
+                {
+                    "target": "id",
+                    "source_fields": ["emp_email"],
+                    "separator": "",
+                },
+            ],
+            "pass_through_unmapped": True,
+        }
+        source = {
+            "emp_email": "jane.doe@company.com",
+            "firstName": "Jane",
+            "middleName": "",
+            "lastName": "Doe",
+            "position": "Senior Engineer",
+            "department": "Engineering",
+            "location": "Toronto",
+            "managerId": "mgr@company.com",
+        }
+        mapper = FieldMapper(config)
+        result = mapper.map_record(source)
 
         assert result["displayName"] == "Jane Doe"
         assert result["id"] == "jane.doe@company.com"
@@ -206,7 +235,7 @@ class TestFieldMapperFullPipeline:
         assert result["jobTitle"] == "Senior Engineer"
         assert result["department"] == "Engineering"
         assert result["location"] == "Toronto"
-        assert result["manager"] == "mgr@company.com"
+        assert result["managerId"] == "mgr@company.com"
 
 
 class TestFieldMapperEdgeCases:

--- a/sam-event-mesh-identity-provider/tests/unit/test_field_mapper.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_field_mapper.py
@@ -195,10 +195,10 @@ class TestFieldMapperFullPipeline:
         # workEmail is excluded, jobTitle renamed to title
         assert result == {"title": "Engineer"}
 
-    def test_hr_system_mapping(self, hr_field_mapping_config, sample_hr_employee):
-        """Verify HR system mapping produces the expected canonical output."""
-        mapper = FieldMapper(hr_field_mapping_config)
-        result = mapper.map_record(sample_hr_employee)
+    def test_jde_mapping(self, jde_field_mapping_config, sample_jde_employee):
+        """Verify JDE-specific mapping produces the expected canonical output."""
+        mapper = FieldMapper(jde_field_mapping_config)
+        result = mapper.map_record(sample_jde_employee)
 
         assert result["displayName"] == "Jane Doe"
         assert result["id"] == "jane.doe@company.com"

--- a/sam-event-mesh-identity-provider/tests/unit/test_provider.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_provider.py
@@ -65,8 +65,27 @@ class TestGetUserProfile:
         }
         result = await provider.get_user_profile({"email": "jane@co.com"})
         assert result["displayName"] == "Jane Doe"
+        # payload_key defaults to lookup_key ("email")
         mock_service.send_request.assert_called_once_with(
             "user_profile", {"email": "jane@co.com"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_payload_key(self, base_config, mock_component):
+        """payload_key controls the key in the request payload, not lookup_key."""
+        base_config["lookup_key"] = "email"
+        base_config["payload_key"] = "userId"
+        mock_svc = MagicMock()
+        mock_svc.send_request = AsyncMock(return_value={"id": "jane@co.com"})
+        mock_svc.cleanup = MagicMock()
+        with patch(
+            "sam_event_mesh_identity_provider.provider.EventMeshService",
+            return_value=mock_svc,
+        ):
+            p = EventMeshIdentityProvider(base_config, mock_component)
+        await p.get_user_profile({"email": "jane@co.com"})
+        mock_svc.send_request.assert_called_once_with(
+            "user_profile", {"userId": "jane@co.com"}
         )
 
     @pytest.mark.asyncio

--- a/sam-event-mesh-identity-provider/tests/unit/test_provider.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_provider.py
@@ -7,47 +7,23 @@ import pandas as pd
 from sam_event_mesh_identity_provider.provider import EventMeshIdentityProvider
 
 
-# All operation names used by the provider.
-ALL_OPS = {"user_profile", "search_users", "employee_data", "employee_profile", "time_off", "profile_picture"}
-
-
-def _make_mock_service(configured_ops=None):
-    """Create a mock EventMeshService with configurable operation availability."""
-    if configured_ops is None:
-        configured_ops = ALL_OPS
+@pytest.fixture
+def mock_service():
+    """A mock EventMeshService."""
     service = MagicMock()
     service.send_request = AsyncMock(return_value=None)
     service.cleanup = MagicMock()
-    service.is_operation_configured = MagicMock(side_effect=lambda op: op in configured_ops)
     return service
 
 
 @pytest.fixture
-def mock_service():
-    """A mock EventMeshService with all operations configured."""
-    return _make_mock_service(ALL_OPS)
-
-
-@pytest.fixture
 def provider(base_config, mock_component, mock_service):
-    """An EventMeshIdentityProvider with mocked service layer (all ops)."""
+    """An EventMeshIdentityProvider with mocked service layer."""
     with patch(
         "sam_event_mesh_identity_provider.provider.EventMeshService",
         return_value=mock_service,
     ):
         p = EventMeshIdentityProvider(base_config, mock_component)
-    return p
-
-
-@pytest.fixture
-def partial_provider(partial_config, mock_component):
-    """Provider with only user_profile configured."""
-    svc = _make_mock_service({"user_profile"})
-    with patch(
-        "sam_event_mesh_identity_provider.provider.EventMeshService",
-        return_value=svc,
-    ):
-        p = EventMeshIdentityProvider(partial_config, mock_component)
     return p
 
 
@@ -320,50 +296,3 @@ class TestGetEmployeeProfilePicture:
         await provider.get_employee_profile_picture("emp1")
         await provider.get_employee_profile_picture("emp1")
         assert mock_service.send_request.call_count == 1
-
-
-class TestUnconfiguredOperations:
-    """Tests that unconfigured operations return None/empty with warnings."""
-
-    @pytest.mark.asyncio
-    async def test_unconfigured_user_profile(self, partial_provider):
-        """user_profile IS configured in partial_provider, so it works."""
-        partial_provider.service.send_request.return_value = {"id": "j@co.com"}
-        result = await partial_provider.get_user_profile({"email": "j@co.com"})
-        assert result is not None
-
-    @pytest.mark.asyncio
-    async def test_unconfigured_search_users(self, partial_provider):
-        """search_users not configured — returns empty list."""
-        result = await partial_provider.search_users("alice")
-        assert result == []
-        partial_provider.service.send_request.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_unconfigured_employee_dataframe(self, partial_provider):
-        """employee_data not configured — returns empty DataFrame."""
-        df = await partial_provider.get_employee_dataframe()
-        assert isinstance(df, pd.DataFrame)
-        assert df.empty
-        partial_provider.service.send_request.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_unconfigured_employee_profile(self, partial_provider):
-        """employee_profile not configured — returns None."""
-        result = await partial_provider.get_employee_profile("emp1")
-        assert result is None
-        partial_provider.service.send_request.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_unconfigured_time_off(self, partial_provider):
-        """time_off not configured — returns empty list."""
-        result = await partial_provider.get_time_off_data("emp1")
-        assert result == []
-        partial_provider.service.send_request.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_unconfigured_profile_picture(self, partial_provider):
-        """profile_picture not configured — returns None."""
-        result = await partial_provider.get_employee_profile_picture("emp1")
-        assert result is None
-        partial_provider.service.send_request.assert_not_called()

--- a/sam-event-mesh-identity-provider/tests/unit/test_provider.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_provider.py
@@ -1,0 +1,369 @@
+"""Unit tests for the EventMeshIdentityProvider class."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import pandas as pd
+
+from sam_event_mesh_identity_provider.provider import EventMeshIdentityProvider
+
+
+# All operation names used by the provider.
+ALL_OPS = {"user_profile", "search_users", "employee_data", "employee_profile", "time_off", "profile_picture"}
+
+
+def _make_mock_service(configured_ops=None):
+    """Create a mock EventMeshService with configurable operation availability."""
+    if configured_ops is None:
+        configured_ops = ALL_OPS
+    service = MagicMock()
+    service.send_request = AsyncMock(return_value=None)
+    service.cleanup = MagicMock()
+    service.is_operation_configured = MagicMock(side_effect=lambda op: op in configured_ops)
+    return service
+
+
+@pytest.fixture
+def mock_service():
+    """A mock EventMeshService with all operations configured."""
+    return _make_mock_service(ALL_OPS)
+
+
+@pytest.fixture
+def provider(base_config, mock_component, mock_service):
+    """An EventMeshIdentityProvider with mocked service layer (all ops)."""
+    with patch(
+        "sam_event_mesh_identity_provider.provider.EventMeshService",
+        return_value=mock_service,
+    ):
+        p = EventMeshIdentityProvider(base_config, mock_component)
+    return p
+
+
+@pytest.fixture
+def partial_provider(partial_config, mock_component):
+    """Provider with only user_profile configured."""
+    svc = _make_mock_service({"user_profile"})
+    with patch(
+        "sam_event_mesh_identity_provider.provider.EventMeshService",
+        return_value=svc,
+    ):
+        p = EventMeshIdentityProvider(partial_config, mock_component)
+    return p
+
+
+class TestProviderInit:
+    """Tests for provider initialization."""
+
+    def test_init_success(self, base_config, mock_component):
+        """Provider initializes correctly with valid config."""
+        with patch("sam_event_mesh_identity_provider.provider.EventMeshService"):
+            p = EventMeshIdentityProvider(base_config, mock_component)
+        assert p.lookup_key == "email"
+        assert p.field_mapper is not None
+
+    def test_init_service_failure_propagates(self, base_config, mock_component):
+        """If EventMeshService raises, provider re-raises."""
+        with patch(
+            "sam_event_mesh_identity_provider.provider.EventMeshService",
+            side_effect=RuntimeError("Connection failed"),
+        ):
+            with pytest.raises(RuntimeError, match="Connection failed"):
+                EventMeshIdentityProvider(base_config, mock_component)
+
+    def test_del_calls_cleanup(self, provider, mock_service):
+        """__del__ calls service.cleanup()."""
+        provider.__del__()
+        mock_service.cleanup.assert_called_once()
+
+
+class TestGetUserProfile:
+    """Tests for get_user_profile."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, provider, mock_service):
+        """Returns mapped profile on successful fetch."""
+        mock_service.send_request.return_value = {
+            "id": "jane@co.com",
+            "displayName": "Jane Doe",
+            "workEmail": "jane@co.com",
+        }
+        result = await provider.get_user_profile({"email": "jane@co.com"})
+        assert result["displayName"] == "Jane Doe"
+        mock_service.send_request.assert_called_once_with(
+            "user_profile", {"email": "jane@co.com"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_cache_hit(self, provider, mock_service):
+        """Second call returns cached result without calling service."""
+        mock_service.send_request.return_value = {"id": "j@co.com", "name": "J"}
+        await provider.get_user_profile({"email": "j@co.com"})
+        await provider.get_user_profile({"email": "j@co.com"})
+        assert mock_service.send_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_claims(self, provider):
+        """Returns None when auth_claims is empty."""
+        assert await provider.get_user_profile({}) is None
+        assert await provider.get_user_profile(None) is None
+
+    @pytest.mark.asyncio
+    async def test_missing_lookup_key(self, provider):
+        """Returns None when lookup_key not in auth_claims."""
+        result = await provider.get_user_profile({"username": "jane"})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_attribute_access(self, provider, mock_service):
+        """Handles auth_claims with attribute access (not just dict)."""
+        mock_service.send_request.return_value = {"id": "j@co.com"}
+
+        class Claims:
+            email = "j@co.com"
+
+        result = await provider.get_user_profile(Claims())
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_service_returns_none(self, provider, mock_service):
+        """Returns None when backend returns nothing."""
+        mock_service.send_request.return_value = None
+        result = await provider.get_user_profile({"email": "missing@co.com"})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_ensures_id_field(self, provider, mock_service):
+        """When response has no id field, lookup value is used."""
+        mock_service.send_request.return_value = {"displayName": "Jane"}
+        result = await provider.get_user_profile({"email": "Jane@CO.com"})
+        assert result["id"] == "jane@co.com"
+
+
+class TestSearchUsers:
+    """Tests for search_users."""
+
+    @pytest.mark.asyncio
+    async def test_success_list_response(self, provider, mock_service):
+        """Returns mapped list when backend returns a list."""
+        mock_service.send_request.return_value = [
+            {"id": "1", "displayName": "Alice"},
+            {"id": "2", "displayName": "Bob"},
+        ]
+        results = await provider.search_users("ali", limit=5)
+        assert len(results) == 2
+        assert results[0]["displayName"] == "Alice"
+
+    @pytest.mark.asyncio
+    async def test_success_dict_response(self, provider, mock_service):
+        """Returns mapped list when backend returns a dict with 'results' key."""
+        mock_service.send_request.return_value = {
+            "results": [{"id": "1", "displayName": "Alice"}]
+        }
+        results = await provider.search_users("ali")
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_short_query(self, provider, mock_service):
+        """Returns empty list for queries shorter than 2 characters."""
+        assert await provider.search_users("a") == []
+        assert await provider.search_users("") == []
+        mock_service.send_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_hit(self, provider, mock_service):
+        """Second identical search returns cached results."""
+        mock_service.send_request.return_value = [{"id": "1"}]
+        await provider.search_users("alice", limit=10)
+        await provider.search_users("alice", limit=10)
+        assert mock_service.send_request.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_results(self, provider, mock_service):
+        """Returns empty list when backend returns None."""
+        mock_service.send_request.return_value = None
+        assert await provider.search_users("nobody") == []
+
+
+class TestGetEmployeeDataframe:
+    """Tests for get_employee_dataframe."""
+
+    @pytest.mark.asyncio
+    async def test_success_list_response(self, provider, mock_service):
+        """Returns DataFrame with mapped columns."""
+        mock_service.send_request.return_value = [
+            {"id": "1", "displayName": "Alice", "department": "Eng"},
+            {"id": "2", "displayName": "Bob", "department": "Sales"},
+        ]
+        df = await provider.get_employee_dataframe()
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 2
+        assert "displayName" in df.columns
+
+    @pytest.mark.asyncio
+    async def test_success_dict_response(self, provider, mock_service):
+        """Returns DataFrame when backend returns dict with 'employees' key."""
+        mock_service.send_request.return_value = {
+            "employees": [{"id": "1", "displayName": "Alice"}]
+        }
+        df = await provider.get_employee_dataframe()
+        assert len(df) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_response(self, provider, mock_service):
+        """Returns empty DataFrame on no data."""
+        mock_service.send_request.return_value = None
+        df = await provider.get_employee_dataframe()
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+
+
+class TestGetEmployeeProfile:
+    """Tests for get_employee_profile."""
+
+    @pytest.mark.asyncio
+    async def test_success(self, provider, mock_service):
+        """Returns mapped profile dict."""
+        mock_service.send_request.return_value = {
+            "id": "emp1",
+            "displayName": "Alice",
+            "department": "Eng",
+        }
+        result = await provider.get_employee_profile("emp1")
+        assert result["displayName"] == "Alice"
+        mock_service.send_request.assert_called_with(
+            "employee_profile", {"employee_id": "emp1"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, provider, mock_service):
+        """Returns None when employee not found."""
+        mock_service.send_request.return_value = None
+        assert await provider.get_employee_profile("missing") is None
+
+    @pytest.mark.asyncio
+    async def test_cache_hit(self, provider, mock_service):
+        """Second call returns cached result."""
+        mock_service.send_request.return_value = {"id": "emp1", "name": "A"}
+        await provider.get_employee_profile("emp1")
+        await provider.get_employee_profile("emp1")
+        assert mock_service.send_request.call_count == 1
+
+
+class TestGetTimeOffData:
+    """Tests for get_time_off_data."""
+
+    @pytest.mark.asyncio
+    async def test_success_list_response(self, provider, mock_service):
+        """Returns list of time-off entries."""
+        mock_service.send_request.return_value = [
+            {"start": "2025-07-04", "end": "2025-07-04", "type": "Holiday", "amount": "full_day"},
+        ]
+        result = await provider.get_time_off_data("emp1")
+        assert len(result) == 1
+        assert result[0]["type"] == "Holiday"
+
+    @pytest.mark.asyncio
+    async def test_success_dict_response(self, provider, mock_service):
+        """Returns entries when backend returns dict with 'entries' key."""
+        mock_service.send_request.return_value = {
+            "entries": [
+                {"start": "2025-08-01", "end": "2025-08-05", "type": "Vacation", "amount": "full_day"}
+            ]
+        }
+        result = await provider.get_time_off_data("emp1")
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_with_date_range(self, provider, mock_service):
+        """start_date and end_date are passed in the request payload."""
+        mock_service.send_request.return_value = []
+        await provider.get_time_off_data("emp1", start_date="2025-01-01", end_date="2025-12-31")
+        mock_service.send_request.assert_called_with(
+            "time_off",
+            {"employee_id": "emp1", "start_date": "2025-01-01", "end_date": "2025-12-31"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_data(self, provider, mock_service):
+        """Returns empty list when no data available."""
+        mock_service.send_request.return_value = None
+        assert await provider.get_time_off_data("emp1") == []
+
+
+class TestGetEmployeeProfilePicture:
+    """Tests for get_employee_profile_picture."""
+
+    @pytest.mark.asyncio
+    async def test_success_string_response(self, provider, mock_service):
+        """Returns data URI when backend returns a string directly."""
+        mock_service.send_request.return_value = "data:image/jpeg;base64,abc123"
+        result = await provider.get_employee_profile_picture("emp1")
+        assert result == "data:image/jpeg;base64,abc123"
+
+    @pytest.mark.asyncio
+    async def test_success_dict_response(self, provider, mock_service):
+        """Returns data URI from dict response with data_uri key."""
+        mock_service.send_request.return_value = {"data_uri": "data:image/png;base64,xyz"}
+        result = await provider.get_employee_profile_picture("emp1")
+        assert result == "data:image/png;base64,xyz"
+
+    @pytest.mark.asyncio
+    async def test_not_found(self, provider, mock_service):
+        """Returns None when no picture available."""
+        mock_service.send_request.return_value = None
+        assert await provider.get_employee_profile_picture("emp1") is None
+
+    @pytest.mark.asyncio
+    async def test_cache_hit(self, provider, mock_service):
+        """Second call returns cached result."""
+        mock_service.send_request.return_value = "data:image/jpeg;base64,abc"
+        await provider.get_employee_profile_picture("emp1")
+        await provider.get_employee_profile_picture("emp1")
+        assert mock_service.send_request.call_count == 1
+
+
+class TestUnconfiguredOperations:
+    """Tests that unconfigured operations return None/empty with warnings."""
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_user_profile(self, partial_provider):
+        """user_profile IS configured in partial_provider, so it works."""
+        partial_provider.service.send_request.return_value = {"id": "j@co.com"}
+        result = await partial_provider.get_user_profile({"email": "j@co.com"})
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_search_users(self, partial_provider):
+        """search_users not configured — returns empty list."""
+        result = await partial_provider.search_users("alice")
+        assert result == []
+        partial_provider.service.send_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_employee_dataframe(self, partial_provider):
+        """employee_data not configured — returns empty DataFrame."""
+        df = await partial_provider.get_employee_dataframe()
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+        partial_provider.service.send_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_employee_profile(self, partial_provider):
+        """employee_profile not configured — returns None."""
+        result = await partial_provider.get_employee_profile("emp1")
+        assert result is None
+        partial_provider.service.send_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_time_off(self, partial_provider):
+        """time_off not configured — returns empty list."""
+        result = await partial_provider.get_time_off_data("emp1")
+        assert result == []
+        partial_provider.service.send_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_profile_picture(self, partial_provider):
+        """profile_picture not configured — returns None."""
+        result = await partial_provider.get_employee_profile_picture("emp1")
+        assert result is None
+        partial_provider.service.send_request.assert_not_called()

--- a/sam-event-mesh-identity-provider/tests/unit/test_service.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_service.py
@@ -1,0 +1,177 @@
+"""Unit tests for the EventMeshService class."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sam_event_mesh_identity_provider.service import EventMeshService
+
+
+class TestServiceInitialization:
+    """Tests for service initialization and session creation."""
+
+    def test_init_creates_session(self, base_config, mock_component):
+        """Initialization calls create_request_response_session."""
+        service = EventMeshService(base_config, mock_component)
+        mock_component.create_request_response_session.assert_called_once()
+        assert service.session_id == "test-session-id"
+
+    def test_init_raises_on_no_config(self, mock_component):
+        """ValueError raised when config is None."""
+        with pytest.raises(ValueError, match="requires a configuration"):
+            EventMeshService(None, mock_component)
+
+    def test_init_raises_on_empty_config(self, mock_component):
+        """ValueError raised when config is empty dict."""
+        with pytest.raises(ValueError, match="requires a configuration"):
+            EventMeshService({}, mock_component)
+
+    def test_init_raises_on_no_component(self, base_config):
+        """ValueError raised when component is None."""
+        with pytest.raises(ValueError, match="requires a SAM component"):
+            EventMeshService(base_config, None)
+
+    def test_init_raises_on_session_failure(self, base_config, mock_component):
+        """Error propagates when session creation fails."""
+        mock_component.create_request_response_session.side_effect = RuntimeError("Broker down")
+        with pytest.raises(RuntimeError, match="Broker down"):
+            EventMeshService(base_config, mock_component)
+
+    def test_init_session_config_values(self, base_config, mock_component):
+        """Session config contains the correct broker and payload settings."""
+        EventMeshService(base_config, mock_component)
+        call_kwargs = mock_component.create_request_response_session.call_args
+        session_config = call_kwargs.kwargs.get("session_config") or call_kwargs[1].get("session_config")
+        assert session_config["broker_config"]["broker_url"] == "tcp://localhost:55555"
+        assert session_config["payload_format"] == "json"
+        assert session_config["request_expiry_ms"] == 120000
+
+    def test_init_loads_operations(self, base_config, mock_component):
+        """Operations dict is loaded from config."""
+        service = EventMeshService(base_config, mock_component)
+        assert "user_profile" in service.operations
+        assert "search_users" in service.operations
+        assert service.operations["user_profile"]["response_topic"] == "test/user-profile/response/"
+
+
+class TestServiceOperationCheck:
+    """Tests for is_operation_configured."""
+
+    def test_configured_operation(self, base_config, mock_component):
+        """Returns True for configured operations."""
+        service = EventMeshService(base_config, mock_component)
+        assert service.is_operation_configured("user_profile") is True
+        assert service.is_operation_configured("employee_data") is True
+
+    def test_unconfigured_operation(self, base_config, mock_component):
+        """Returns False for operations not in config."""
+        service = EventMeshService(base_config, mock_component)
+        assert service.is_operation_configured("nonexistent") is False
+
+    def test_partial_config(self, partial_config, mock_component):
+        """Only configured operations return True."""
+        service = EventMeshService(partial_config, mock_component)
+        assert service.is_operation_configured("user_profile") is True
+        assert service.is_operation_configured("search_users") is False
+        assert service.is_operation_configured("employee_data") is False
+
+
+class TestServiceSendRequest:
+    """Tests for the send_request method."""
+
+    @pytest.mark.asyncio
+    async def test_send_request_success(self, base_config, mock_component):
+        """Successful request returns the response payload."""
+        mock_response = MagicMock()
+        mock_response.get_payload.return_value = {"name": "Jane", "email": "j@co.com"}
+        mock_component.do_broker_request_response_async = AsyncMock(return_value=mock_response)
+
+        service = EventMeshService(base_config, mock_component)
+        result = await service.send_request("user_profile", {"email": "j@co.com"})
+
+        assert result == {"name": "Jane", "email": "j@co.com"}
+        mock_component.do_broker_request_response_async.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_request_unconfigured_operation(self, base_config, mock_component):
+        """Returns None with warning for an operation not in config."""
+        service = EventMeshService(base_config, mock_component)
+        result = await service.send_request("nonexistent_op", {"foo": "bar"})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_send_request_topic_formatting(self, base_config, mock_component):
+        """Request ID is interpolated into the topic template."""
+        mock_response = MagicMock()
+        mock_response.get_payload.return_value = {}
+        mock_component.do_broker_request_response_async = AsyncMock(return_value=mock_response)
+
+        service = EventMeshService(base_config, mock_component)
+        await service.send_request("user_profile", {"email": "a@b.com"})
+
+        call_args = mock_component.do_broker_request_response_async.call_args
+        message = call_args[0][0]
+        # Topic should start with "test/user-profile/" followed by a UUID
+        assert message.get_topic().startswith("test/user-profile/")
+        assert len(message.get_topic().split("/")[-1]) == 36  # UUID length
+
+    @pytest.mark.asyncio
+    async def test_send_request_exception_returns_none(self, base_config, mock_component):
+        """Returns None when broker request raises an exception."""
+        mock_component.do_broker_request_response_async = AsyncMock(
+            side_effect=TimeoutError("Request timed out")
+        )
+        service = EventMeshService(base_config, mock_component)
+        result = await service.send_request("user_profile", {"email": "a@b.com"})
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_send_request_passes_payload(self, base_config, mock_component):
+        """The request payload is passed correctly in the message."""
+        mock_response = MagicMock()
+        mock_response.get_payload.return_value = {}
+        mock_component.do_broker_request_response_async = AsyncMock(return_value=mock_response)
+
+        service = EventMeshService(base_config, mock_component)
+        payload = {"employee_id": "emp123", "extra": "data"}
+        await service.send_request("employee_profile", payload)
+
+        call_args = mock_component.do_broker_request_response_async.call_args
+        message = call_args[0][0]
+        assert message.get_payload() == payload
+
+    @pytest.mark.asyncio
+    async def test_send_request_partial_config_only_configured_ops_work(
+        self, partial_config, mock_component
+    ):
+        """Only the configured operation works; unconfigured ones return None."""
+        mock_response = MagicMock()
+        mock_response.get_payload.return_value = {"id": "1"}
+        mock_component.do_broker_request_response_async = AsyncMock(return_value=mock_response)
+
+        service = EventMeshService(partial_config, mock_component)
+
+        # Configured operation works
+        result = await service.send_request("user_profile", {"email": "a@b.com"})
+        assert result == {"id": "1"}
+
+        # Unconfigured operations return None
+        assert await service.send_request("search_users", {"query": "a"}) is None
+        assert await service.send_request("employee_data", {}) is None
+
+
+class TestServiceCleanup:
+    """Tests for cleanup behavior."""
+
+    def test_cleanup_destroys_session(self, base_config, mock_component):
+        """cleanup() calls destroy_request_response_session."""
+        service = EventMeshService(base_config, mock_component)
+        service.cleanup()
+        mock_component.destroy_request_response_session.assert_called_once_with("test-session-id")
+        assert service.session_id is None
+
+    def test_cleanup_safe_when_no_session(self, base_config, mock_component):
+        """cleanup() is safe when session_id is already None."""
+        service = EventMeshService(base_config, mock_component)
+        service.session_id = None
+        service.cleanup()  # Should not raise
+        mock_component.destroy_request_response_session.assert_not_called()

--- a/sam-event-mesh-identity-provider/tests/unit/test_service.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_service.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from sam_event_mesh_identity_provider.service import EventMeshService
+from sam_event_mesh_identity_provider.service import EventMeshService, ALL_OPERATIONS
 
 
 class TestServiceInitialization:
@@ -45,34 +45,27 @@ class TestServiceInitialization:
         assert session_config["payload_format"] == "json"
         assert session_config["request_expiry_ms"] == 120000
 
-    def test_init_loads_operations(self, base_config, mock_component):
-        """Operations dict is loaded from config."""
+
+class TestServiceBackwardCompat:
+    """Tests for flat-config backward compatibility."""
+
+    def test_flat_config_creates_all_operations(self, flat_config, mock_component):
+        """When operations is absent but request_topic is present, all ops are created."""
+        service = EventMeshService(flat_config, mock_component)
+        for op in ALL_OPERATIONS:
+            assert op in service.operations
+            assert service.operations[op]["request_topic"] == flat_config["request_topic"]
+
+    def test_flat_config_uses_response_topic_as_prefix(self, flat_config, mock_component):
+        """Flat response_topic becomes the response_topic_prefix."""
+        service = EventMeshService(flat_config, mock_component)
+        assert service.response_topic_prefix == "TI/AI/HRM/user/retrieved/v1/"
+
+    def test_explicit_operations_takes_precedence(self, base_config, mock_component):
+        """When operations is present, flat request_topic is ignored."""
+        base_config["request_topic"] = "should/be/ignored/{request_id}"
         service = EventMeshService(base_config, mock_component)
-        assert "user_profile" in service.operations
-        assert "search_users" in service.operations
-        assert service.operations["user_profile"]["response_topic"] == "test/user-profile/response/"
-
-
-class TestServiceOperationCheck:
-    """Tests for is_operation_configured."""
-
-    def test_configured_operation(self, base_config, mock_component):
-        """Returns True for configured operations."""
-        service = EventMeshService(base_config, mock_component)
-        assert service.is_operation_configured("user_profile") is True
-        assert service.is_operation_configured("employee_data") is True
-
-    def test_unconfigured_operation(self, base_config, mock_component):
-        """Returns False for operations not in config."""
-        service = EventMeshService(base_config, mock_component)
-        assert service.is_operation_configured("nonexistent") is False
-
-    def test_partial_config(self, partial_config, mock_component):
-        """Only configured operations return True."""
-        service = EventMeshService(partial_config, mock_component)
-        assert service.is_operation_configured("user_profile") is True
-        assert service.is_operation_configured("search_users") is False
-        assert service.is_operation_configured("employee_data") is False
+        assert service.operations["user_profile"]["request_topic"] == "test/user-profile/{request_id}"
 
 
 class TestServiceSendRequest:
@@ -92,8 +85,8 @@ class TestServiceSendRequest:
         mock_component.do_broker_request_response_async.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_send_request_unconfigured_operation(self, base_config, mock_component):
-        """Returns None with warning for an operation not in config."""
+    async def test_send_request_unknown_operation(self, base_config, mock_component):
+        """Returns None for an operation not in config."""
         service = EventMeshService(base_config, mock_component)
         result = await service.send_request("nonexistent_op", {"foo": "bar"})
         assert result is None
@@ -138,25 +131,6 @@ class TestServiceSendRequest:
         call_args = mock_component.do_broker_request_response_async.call_args
         message = call_args[0][0]
         assert message.get_payload() == payload
-
-    @pytest.mark.asyncio
-    async def test_send_request_partial_config_only_configured_ops_work(
-        self, partial_config, mock_component
-    ):
-        """Only the configured operation works; unconfigured ones return None."""
-        mock_response = MagicMock()
-        mock_response.get_payload.return_value = {"id": "1"}
-        mock_component.do_broker_request_response_async = AsyncMock(return_value=mock_response)
-
-        service = EventMeshService(partial_config, mock_component)
-
-        # Configured operation works
-        result = await service.send_request("user_profile", {"email": "a@b.com"})
-        assert result == {"id": "1"}
-
-        # Unconfigured operations return None
-        assert await service.send_request("search_users", {"query": "a"}) is None
-        assert await service.send_request("employee_data", {}) is None
 
 
 class TestServiceCleanup:

--- a/sam-event-mesh-identity-provider/tests/unit/test_service.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_service.py
@@ -1,7 +1,7 @@
 """Unit tests for the EventMeshService class."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from sam_event_mesh_identity_provider.service import EventMeshService, ALL_OPERATIONS
 
@@ -46,26 +46,47 @@ class TestServiceInitialization:
         assert session_config["request_expiry_ms"] == 120000
 
 
-class TestServiceBackwardCompat:
-    """Tests for flat-config backward compatibility."""
+class TestRequestTopicFormats:
+    """Tests for string vs dict request_topic config."""
 
-    def test_flat_config_creates_all_operations(self, flat_config, mock_component):
-        """When operations is absent but request_topic is present, all ops are created."""
-        service = EventMeshService(flat_config, mock_component)
+    def test_string_topic_creates_all_operations(self, string_topic_config, mock_component):
+        """A string request_topic applies to every operation."""
+        service = EventMeshService(string_topic_config, mock_component)
         for op in ALL_OPERATIONS:
-            assert op in service.operations
-            assert service.operations[op]["request_topic"] == flat_config["request_topic"]
+            assert op in service.topic_map
+            assert service.topic_map[op] == string_topic_config["request_topic"]
 
-    def test_flat_config_uses_response_topic_as_prefix(self, flat_config, mock_component):
-        """Flat response_topic becomes the response_topic_prefix."""
-        service = EventMeshService(flat_config, mock_component)
-        assert service.response_topic_prefix == "TI/AI/HRM/user/retrieved/v1/"
-
-    def test_explicit_operations_takes_precedence(self, base_config, mock_component):
-        """When operations is present, flat request_topic is ignored."""
-        base_config["request_topic"] = "should/be/ignored/{request_id}"
+    def test_dict_topic_uses_per_operation(self, base_config, mock_component):
+        """A dict request_topic maps each operation to its own topic."""
         service = EventMeshService(base_config, mock_component)
-        assert service.operations["user_profile"]["request_topic"] == "test/user-profile/{request_id}"
+        assert service.topic_map["user_profile"] == "test/user-profile/{request_id}"
+        assert service.topic_map["employee_data"] == "test/employee-data/{request_id}"
+
+    def test_dict_topic_missing_operation_returns_none(self, mock_component):
+        """Operations not listed in a dict request_topic return None."""
+        config = {
+            "broker_url": "tcp://localhost:55555",
+            "broker_vpn": "default",
+            "broker_username": "user",
+            "broker_password": "pass",
+            "request_topic": {
+                "user_profile": "test/user-profile/{request_id}",
+            },
+        }
+        service = EventMeshService(config, mock_component)
+        assert "search_users" not in service.topic_map
+
+    def test_invalid_request_topic_type_raises(self, mock_component):
+        """ValueError raised when request_topic is neither string nor dict."""
+        config = {
+            "broker_url": "tcp://localhost:55555",
+            "broker_vpn": "default",
+            "broker_username": "user",
+            "broker_password": "pass",
+            "request_topic": 12345,
+        }
+        with pytest.raises(ValueError, match="must be a string or dict"):
+            EventMeshService(config, mock_component)
 
 
 class TestServiceSendRequest:
@@ -85,10 +106,19 @@ class TestServiceSendRequest:
         mock_component.do_broker_request_response_async.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_send_request_unknown_operation(self, base_config, mock_component):
-        """Returns None for an operation not in config."""
-        service = EventMeshService(base_config, mock_component)
-        result = await service.send_request("nonexistent_op", {"foo": "bar"})
+    async def test_send_request_unconfigured_operation(self, mock_component):
+        """Returns None with warning for an operation not in the topic map."""
+        config = {
+            "broker_url": "tcp://localhost:55555",
+            "broker_vpn": "default",
+            "broker_username": "user",
+            "broker_password": "pass",
+            "request_topic": {
+                "user_profile": "test/user-profile/{request_id}",
+            },
+        }
+        service = EventMeshService(config, mock_component)
+        result = await service.send_request("search_users", {"query": "alice"})
         assert result is None
 
     @pytest.mark.asyncio

--- a/sam-event-mesh-identity-provider/tests/unit/test_service.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_service.py
@@ -44,6 +44,18 @@ class TestServiceInitialization:
         assert session_config["broker_config"]["broker_url"] == "tcp://localhost:55555"
         assert session_config["payload_format"] == "json"
         assert session_config["request_expiry_ms"] == 120000
+        assert session_config["user_properties_reply_topic_key"] == "replyTopic"
+        assert session_config["response_topic_insertion_expression"] == "replyTopic"
+
+    def test_init_custom_reply_topic_keys(self, base_config, mock_component):
+        """Custom reply topic keys are passed to the session config."""
+        base_config["user_properties_reply_topic_key"] = "custom.reply.key"
+        base_config["response_topic_insertion_expression"] = "customReplyTopic"
+        EventMeshService(base_config, mock_component)
+        call_kwargs = mock_component.create_request_response_session.call_args
+        session_config = call_kwargs.kwargs.get("session_config") or call_kwargs[1].get("session_config")
+        assert session_config["user_properties_reply_topic_key"] == "custom.reply.key"
+        assert session_config["response_topic_insertion_expression"] == "customReplyTopic"
 
 
 class TestRequestTopicFormats:


### PR DESCRIPTION
### What is the purpose of this change?

    This plugin provides a generic, vendor-agnostic identity and employee service provider for Solace Agent Mesh that communicates with backend systems via the Solace event broker using request-response messaging. It eliminates the need for custom code when integrating with HR or identity systems.

### How was this change implemented?

    High-level approach:
    - Created a new plugin that implements both BaseIdentityService and BaseEmployeeService interfaces
    - Built an EventMeshService class for Solace request-response communication
    - Added a configurable field mapping engine to transform backend data into canonical format
    - Implemented support for all identity and employee service operations
    - Added comprehensive test coverage for all components
    - feat: Implement EventMeshService for request-response communication via Solace broker

### Key Design Decisions

    Rather than creating separate plugins for different backend systems (Workday, BambooHR, etc.), this plugin provides a single configurable solution that works with any backend. Configurable topics and field mappings allow users to adapt to their specific backend systems without modifying code, while the caching layer improves performance.

### How was this change tested?

- [x] Manual testing: Verified request-response flow with Solace broker
- [x] Unit tests: Added comprehensive tests for all components (field_mapper, provider, service)
- [ ] Integration tests: Not applicable at this stage
- [ ] Known limitations: Real-world integration testing with specific HR systems will be needed

### Is there anything the reviewers should focus on/be aware of?

    The plugin can be used in two roles: as an identity service for gateway identity enrichment, and as a people/employee service for agent employee queries. Operations can be selectively enabled.