### PR TITLE
feat(DATAGO-131375): Enhance field mapping engine with default values phase

### DIFF
--- a/sam-event-mesh-identity-provider/README.md
+++ b/sam-event-mesh-identity-provider/README.md
@@ -148,13 +148,26 @@ Available operation keys: `user_profile`, `search_users`, `employee_data`, `empl
 
 ## Field Mapping Guide
 
-The field mapping engine transforms source data through a three-phase pipeline:
+The field mapping engine transforms source data through a four-phase pipeline:
 
 ```
-Source Data -> [1. Field Mapping] -> [2. Exclusion] -> [3. Renaming] -> Output
-                                  ^
-                      [Computed Fields]
+Source Data -> [0. Defaults] -> [1. Field Mapping] -> [2. Exclusion] -> [3. Renaming] -> Output
+                                                   ^
+                                       [Computed Fields]
 ```
+
+### Phase 0: default_values
+
+Fill in defaults on the source record before any mapping runs. A default is applied when the source field is **missing, `None`, empty string, or `0`**. Explicit `False` is preserved.
+
+```yaml
+default_values:
+  country: "unknown"
+  department: "unassigned"
+  hours: 40
+```
+
+Because defaults run first, they are visible to `field_mapping` and `computed_fields` — e.g., a default `country_code` can be remapped to `country`, or a default `middleName` can feed into a `displayName` template.
 
 ### Phase 1: field_mapping
 

--- a/sam-event-mesh-identity-provider/config.yaml
+++ b/sam-event-mesh-identity-provider/config.yaml
@@ -62,6 +62,12 @@ identity_service: # Or people_service:
   # If omitted or empty, source fields pass through unchanged.
   field_mapping_config:
 
+    # Phase 0: Default values applied to the source record before mapping.
+    # Keys are source field names; a default is applied when the source field
+    # is missing, None, empty string, or 0.
+    # Example: { "country": "unknown", "department": "unassigned" }
+    default_values: {}
+
     # Phase 1: Map source field names to canonical field names.
     # Only needed when the source system uses different field names.
     # Example: { "emp_email": "workEmail", "title": "jobTitle" }

--- a/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/field_mapper.py
+++ b/sam-event-mesh-identity-provider/src/sam_event_mesh_identity_provider/field_mapper.py
@@ -8,8 +8,10 @@ log = logging.getLogger(__name__)
 
 class FieldMapper:
     """
-    Transforms source records to canonical output format using a three-phase pipeline:
+    Transforms source records to canonical output format using a four-phase pipeline:
 
+    0. default_values: fill in defaults on the source record for fields that are
+       missing, None, empty string, or 0
     1. field_mapping: rename source fields to canonical field names
     2. exclusion_list: remove unwanted fields from the output
     3. rename_mapping: rename fields to custom output names
@@ -19,6 +21,7 @@ class FieldMapper:
     """
 
     def __init__(self, config: Dict[str, Any]):
+        self.default_values: Dict[str, Any] = config.get("default_values", {})
         self.field_mapping: Dict[str, str] = config.get("field_mapping", {})
         self.exclusion_list: List[str] = config.get("exclusion_list", [])
         self.rename_mapping: Dict[str, str] = config.get("rename_mapping", {})
@@ -38,6 +41,10 @@ class FieldMapper:
         if not source:
             return None
 
+        # Phase 0: Apply defaults to the source record before anything else so
+        # that downstream mapping and computed fields see the filled-in values.
+        source = self._apply_defaults(source)
+
         # Phase 1: Apply field_mapping (source -> canonical)
         canonical = self._apply_field_mapping(source)
 
@@ -49,6 +56,25 @@ class FieldMapper:
 
         # Phase 3: Apply rename_mapping (canonical -> output)
         return self._apply_rename_mapping(canonical)
+
+    def _apply_defaults(self, source: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Return a copy of ``source`` with ``default_values`` filled in for fields
+        that are missing or whose value is ``None``, empty string, or ``0``.
+        The original ``source`` is not mutated.
+        """
+        if not self.default_values:
+            return source
+
+        enriched = dict(source)
+        for key, default in self.default_values.items():
+            current = enriched.get(key)
+            # Treat False separately so it isn't swept up by `0 == False`.
+            if current is False:
+                continue
+            if key not in enriched or current is None or current == "" or current == 0:
+                enriched[key] = default
+        return enriched
 
     def _apply_field_mapping(self, source: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/sam-event-mesh-identity-provider/tests/unit/test_field_mapper.py
+++ b/sam-event-mesh-identity-provider/tests/unit/test_field_mapper.py
@@ -179,6 +179,78 @@ class TestFieldMapperComputedFields:
         assert result == {}
 
 
+class TestFieldMapperDefaults:
+    """Tests for default_values (Phase 0)."""
+
+    def test_default_applied_when_field_missing(self):
+        """Default fills in a field absent from the source."""
+        mapper = FieldMapper({"default_values": {"country": "unknown"}})
+        result = mapper.map_record({"id": "1"})
+        assert result == {"id": "1", "country": "unknown"}
+
+    def test_default_applied_when_value_is_none(self):
+        """Default replaces a None value."""
+        mapper = FieldMapper({"default_values": {"country": "unknown"}})
+        result = mapper.map_record({"id": "1", "country": None})
+        assert result["country"] == "unknown"
+
+    def test_default_applied_when_value_is_empty_string(self):
+        """Default replaces an empty string."""
+        mapper = FieldMapper({"default_values": {"country": "unknown"}})
+        result = mapper.map_record({"id": "1", "country": ""})
+        assert result["country"] == "unknown"
+
+    def test_default_applied_when_value_is_zero(self):
+        """Default replaces a 0 value."""
+        mapper = FieldMapper({"default_values": {"hours": 40}})
+        result = mapper.map_record({"id": "1", "hours": 0})
+        assert result["hours"] == 40
+
+    def test_default_not_applied_when_value_is_false(self):
+        """Default does not replace an explicit False (distinguished from 0)."""
+        mapper = FieldMapper({"default_values": {"active": True}})
+        result = mapper.map_record({"id": "1", "active": False})
+        assert result["active"] is False
+
+    def test_default_not_applied_when_value_present(self):
+        """Default leaves a populated field alone."""
+        mapper = FieldMapper({"default_values": {"country": "unknown"}})
+        result = mapper.map_record({"id": "1", "country": "Canada"})
+        assert result["country"] == "Canada"
+
+    def test_default_feeds_into_field_mapping(self):
+        """A default applied to a source key flows through field_mapping."""
+        mapper = FieldMapper({
+            "default_values": {"country_code": "XX"},
+            "field_mapping": {"country_code": "country"},
+            "pass_through_unmapped": False,
+        })
+        result = mapper.map_record({"id": "1"})
+        assert result == {"country": "XX"}
+
+    def test_default_feeds_into_computed_fields(self):
+        """A default is visible to template-based computed fields."""
+        mapper = FieldMapper({
+            "default_values": {"middleName": "X"},
+            "computed_fields": [
+                {
+                    "target": "displayName",
+                    "source_fields": ["firstName", "middleName", "lastName"],
+                    "separator": " ",
+                }
+            ],
+        })
+        result = mapper.map_record({"firstName": "Jane", "lastName": "Doe"})
+        assert result["displayName"] == "Jane X Doe"
+
+    def test_does_not_mutate_source(self):
+        """Applying defaults does not modify the caller's dict."""
+        mapper = FieldMapper({"default_values": {"country": "unknown"}})
+        source = {"id": "1"}
+        mapper.map_record(source)
+        assert source == {"id": "1"}
+
+
 class TestFieldMapperFullPipeline:
     """Tests for the complete three-phase pipeline."""
 


### PR DESCRIPTION
### What is the purpose of this change?

This change enhances the field mapping engine with a new "defaults" phase that allows specifying default values for fields that are missing or empty in source records. This solves the problem of handling incomplete data from backend systems without requiring conditional logic in downstream code.

### How was this change implemented?

The field mapping engine was extended from a three-phase to a four-phase pipeline by adding a new initial "Phase 0" for defaults:

- feat: Enhance field mapping engine with default values phase
- Added `default_values` configuration in the field mapping config
- Updated the README documentation to describe the new defaults phase
- Implemented the `_apply_defaults` method in the `FieldMapper` class
- Added comprehensive unit tests for the defaults functionality

### Key Design Decisions

The default values phase runs first in the pipeline, allowing defaults to feed into downstream mapping operations and computed fields. This approach is more powerful than applying defaults at the end, as it allows default values to participate in field transformations.

The implementation carefully handles edge cases by applying defaults when values are missing, None, empty string, or 0, while preserving explicit False values to distinguish from numeric zeros.

### How was this change tested?

- [x] Manual testing: Verified with sample configurations using missing/empty fields
- [x] Unit tests: Added 8 new test cases covering all default value scenarios
- [ ] Integration tests: Not applicable
- [ ] Known limitations: Default values don't apply to nested structures

### Is there anything the reviewers should focus on/be aware of?

The distinction between 0 and False handling is important - please verify this behavior is correct for your use cases.