### PR TITLE
fix(DATAGO-126526): Slack gateway crashes with msg_too_long when response exceeds 40K characters

### DIFF
--- a/sam-slack-gateway-adapter/src/sam_slack_gateway_adapter/message_queue.py
+++ b/sam-slack-gateway-adapter/src/sam_slack_gateway_adapter/message_queue.py
@@ -30,6 +30,12 @@ DEFAULT_MAX_RETRIES = 5
 DEFAULT_RETRY_DELAY = 3.0  # seconds - constant delay between retries
 DEFAULT_MAX_RETRY_DELAY = 30.0  # seconds - cap for Retry-After header values
 
+# Slack's hard limit on `text` for chat.postMessage / chat.update.
+# Sending a payload over this fails server-side with `msg_too_long`.
+# Reference: https://api.slack.com/methods/chat.postMessage#truncating
+SLACK_MAX_MESSAGE_LENGTH = 40_000
+SLACK_TRUNCATION_INDICATOR = "\n[…earlier output truncated to fit Slack's 40K limit…]\n"
+
 # Slack Rate Limit Tiers
 # https://api.slack.com/docs/rate-limits
 #
@@ -308,6 +314,29 @@ async def retry_with_backoff(
         raise last_exception
 
 
+def _truncate_for_slack(text: str, task_id: Optional[str] = None) -> str:
+    """
+    Guarantee a payload fits in chat.postMessage / chat.update `text` (~40K).
+
+    Streamed buffers and citation expansion can both grow text past the
+    server-side limit; sending it raises `msg_too_long`, which has no
+    automatic recovery.  We keep the most recent content (the tail of the
+    message is what users see last) and prefix a short indicator.
+    """
+    if len(text) <= SLACK_MAX_MESSAGE_LENGTH:
+        return text
+    keep = SLACK_MAX_MESSAGE_LENGTH - len(SLACK_TRUNCATION_INDICATOR)
+    log.warning(
+        "[Queue:%s] Truncating Slack text payload from %d to %d chars to "
+        "fit Slack's per-message limit (%d)",
+        task_id or "?",
+        len(text),
+        keep + len(SLACK_TRUNCATION_INDICATOR),
+        SLACK_MAX_MESSAGE_LENGTH,
+    )
+    return SLACK_TRUNCATION_INDICATOR + text[-keep:]
+
+
 # --- Queue Operation Types ---
 
 
@@ -424,14 +453,15 @@ class SlackMessageQueue:
         # a no-op update.
         #
         # Note: text_buffer grows for the lifetime of the current text
-        # segment.  For very long-running tasks this could be significant,
-        # but it is bounded by Slack's ~40K message limit in practice.
-        # A hard cap (_text_buffer_max_size) is enforced in
-        # _handle_text_update to prevent runaway growth.
+        # segment.  A hard cap (_text_buffer_max_size) is enforced in
+        # _handle_text_update; we cap at Slack's chat.update text limit
+        # so the buffer can never produce an over-limit payload, and the
+        # formatted output is also truncated at send-time as a final guard
+        # (citation expansion can grow text past the buffer cap).
         self.current_text_message_ts: Optional[str] = None
         self.text_buffer: str = ""
         self.last_posted_formatted_text: str = ""
-        self._text_buffer_max_size: int = 100_000  # chars — well above Slack's 40K limit
+        self._text_buffer_max_size: int = SLACK_MAX_MESSAGE_LENGTH
 
         # For update coalescing - holds non-text ops found during drain
         self._deferred_operation: Optional[QueueOperation] = None
@@ -567,13 +597,26 @@ class SlackMessageQueue:
 
                 if isinstance(operation, StopSignal):
                     log.debug("[Queue:%s] Received stop signal", self.task_id)
-                    # Flush any remaining buffered text as final update
+                    # Flush any remaining buffered text as final update.
+                    # A failed flush (e.g. msg_too_long after a truncation
+                    # bug, or a transient Slack error) must not be treated
+                    # as a fatal queue error -- we still need to mark the
+                    # signal done and exit cleanly.
                     if self.text_buffer:
                         log.debug(
                             "[Queue:%s] Flushing remaining buffer (%d chars) on stop",
                             self.task_id, len(self.text_buffer)
                         )
-                        await self._handle_text_update(TextUpdateOp(text=""), is_final=True)
+                        try:
+                            await self._handle_text_update(
+                                TextUpdateOp(text=""), is_final=True
+                            )
+                        except Exception as flush_err:
+                            log.warning(
+                                "[Queue:%s] Final stop-flush failed (%s); "
+                                "exiting queue cleanly",
+                                self.task_id, flush_err,
+                            )
                     self.queue.task_done()
                     break
 
@@ -713,7 +756,8 @@ class SlackMessageQueue:
         
         # Format the FULL buffer (pass task_id for citation map lookup)
         formatted_text = self.adapter._format_text(self.text_buffer, task_id=self.task_id)
-        
+        formatted_text = _truncate_for_slack(formatted_text, self.task_id)
+
         # Reset retry counter for this send attempt
         self._throttle_retry_count = 0
         
@@ -865,16 +909,28 @@ class SlackMessageQueue:
         This is the critical operation that prevents race conditions.
         """
 
-        # Step 1: Finalize any pending text message (with retry and throttle)
+        # Step 1: Finalize any pending text message (with retry and throttle).
+        # A failure here (e.g. msg_too_long, or a transient Slack error) must
+        # NOT prevent the file from being uploaded -- otherwise users lose the
+        # primary deliverable when the streamed status text happens to be
+        # malformed/oversized.  Truncate to Slack's limit as a guard, then
+        # swallow any remaining error.
         if self.text_buffer and self.current_text_message_ts:
-            await self._throttle(is_message_update=True)
-            await retry_with_backoff(
-                self.client.chat_update,
-                channel=self.channel_id,
-                ts=self.current_text_message_ts,
-                text=self.text_buffer,
-                operation_name=f"[Queue:{self.task_id}] chat_update (finalize text)",
-            )
+            try:
+                await self._throttle(is_message_update=True)
+                await retry_with_backoff(
+                    self.client.chat_update,
+                    channel=self.channel_id,
+                    ts=self.current_text_message_ts,
+                    text=_truncate_for_slack(self.text_buffer, self.task_id),
+                    operation_name=f"[Queue:{self.task_id}] chat_update (finalize text)",
+                )
+            except Exception as flush_err:
+                log.warning(
+                    "[Queue:%s] Pre-upload text flush failed (%s); "
+                    "continuing with file upload of %s",
+                    self.task_id, flush_err, op.filename,
+                )
 
         # Step 2: Reset text state (forces next text to a new message)
         self.text_buffer = ""

--- a/sam-slack-gateway-adapter/tests/unit/test_message_queue_msg_too_long.py
+++ b/sam-slack-gateway-adapter/tests/unit/test_message_queue_msg_too_long.py
@@ -1,0 +1,254 @@
+"""
+Red/green tests for the Slack `msg_too_long` failure path observed on task
+gdk-task-65dbbce024c744e9a68b3de518e73443 (2026-04-26 10:21 UTC).
+
+Symptom: a streaming text buffer was allowed to grow past Slack's chat.update
+text limit (~40K chars).  The resulting `msg_too_long` error from chat.update
+(a) crashed the queue processor when it fired during the StopSignal flush,
+and (b) aborted file-upload handling before `files_getUploadURLExternal` was
+even called -- so the deliverable artifact never reached Slack.
+
+These tests pin the contract:
+  * The queue must never send a `chat.update`/`chat.postMessage` with text
+    exceeding Slack's per-message limit.
+  * A failed text-buffer flush during a file upload must NOT prevent the
+    file-upload API calls from running.
+  * A failed text-buffer flush during stop must NOT propagate as a fatal
+    error from the queue processor.
+
+Run:
+    cd sam-slack-gateway-adapter
+    uv run pytest tests/unit/test_message_queue_msg_too_long.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from sam_slack_gateway_adapter.message_queue import SlackMessageQueue
+
+
+# Slack accepts up to 40_000 chars in chat.{postMessage,update} `text`.
+SLACK_MAX_MESSAGE_LENGTH = 40_000
+
+
+# --- Helpers ---------------------------------------------------------------
+
+
+def _make_msg_too_long_error() -> SlackApiError:
+    """Build a SlackApiError that mimics a real msg_too_long failure."""
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {}
+    response.data = {"ok": False, "error": "msg_too_long"}
+    response.get = lambda key, default=None: response.data.get(key, default)
+    response.__getitem__ = lambda self_, key: response.data[key]  # type: ignore[assignment]
+    return SlackApiError(
+        message="The request to the Slack API failed.",
+        response=response,
+    )
+
+
+def _make_slack_client(*, fail_chat_update_when_over: int | None = None) -> AsyncMock:
+    """
+    Build a slack client mock.
+
+    If `fail_chat_update_when_over` is set, chat_update raises msg_too_long
+    whenever the `text` argument exceeds that many characters (mirroring
+    Slack's real server-side behavior).
+    """
+    client = AsyncMock()
+    client.chat_postMessage = AsyncMock(return_value={"ok": True, "ts": "111.222"})
+    client.chat_delete = AsyncMock(return_value={"ok": True})
+    client.files_getUploadURLExternal = AsyncMock(
+        return_value={"upload_url": "https://upload.test", "file_id": "F-test"}
+    )
+    client.files_completeUploadExternal = AsyncMock(return_value={"ok": True})
+
+    # Make files.info return the file as "visible" immediately so the
+    # upload handler doesn't sit in its polling loop.
+    client.files_info = AsyncMock(
+        return_value={
+            "ok": True,
+            "file": {"shares": {"private": {"C-channel": [{"ts": "1"}]}}},
+        }
+    )
+
+    if fail_chat_update_when_over is not None:
+        threshold = fail_chat_update_when_over
+
+        async def _chat_update(**kwargs: Any) -> dict:
+            text = kwargs.get("text", "") or ""
+            if len(text) > threshold:
+                raise _make_msg_too_long_error()
+            return {"ok": True, "ts": kwargs.get("ts", "111.222")}
+
+        client.chat_update = AsyncMock(side_effect=_chat_update)
+    else:
+        client.chat_update = AsyncMock(return_value={"ok": True, "ts": "111.222"})
+    return client
+
+
+def _make_adapter() -> MagicMock:
+    """Adapter mock with `_format_text` as identity (no transformation)."""
+    adapter = MagicMock()
+    adapter._format_text = MagicMock(side_effect=lambda text, task_id=None: text)
+    adapter.context = MagicMock()
+    return adapter
+
+
+def _make_queue(client: AsyncMock, channel: str = "C-channel") -> SlackMessageQueue:
+    return SlackMessageQueue(
+        task_id="gdk-task-test",
+        slack_client=client,
+        channel_id=channel,
+        thread_ts="111.000",
+        adapter=_make_adapter(),
+    )
+
+
+# Avoid the global rate limiter sleeping during tests.
+@pytest.fixture(autouse=True)
+def _patch_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    import requests
+
+    from sam_slack_gateway_adapter import message_queue
+
+    async def _no_throttle(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr(
+        message_queue.GlobalRateLimiter, "throttle", _no_throttle, raising=True
+    )
+    # Short-circuit asyncio.sleep so retry/backoff/poll loops don't slow tests.
+    real_sleep = asyncio.sleep
+
+    async def _fast_sleep(seconds: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+
+    # The file-upload path POSTs the binary to a Slack-issued upload URL via
+    # the `requests` library; stub it so the test never touches the network.
+    fake_response = MagicMock()
+    fake_response.raise_for_status = MagicMock(return_value=None)
+    monkeypatch.setattr(requests, "post", MagicMock(return_value=fake_response))
+
+
+# --- Tests -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_text_update_never_exceeds_slack_limit() -> None:
+    """
+    RED before fix: the queue calls `chat.update` with the raw text_buffer,
+    which can exceed Slack's 40_000-char text limit.  This test asserts that
+    every call into the slack client is at-or-under the limit.
+
+    GREEN after fix: text is truncated to the limit before being sent.
+    """
+    client = _make_slack_client()
+    queue = _make_queue(client)
+    await queue.start()
+
+    # Push a single oversized chunk — well above Slack's 40K limit.
+    huge_text = "x" * 60_000
+    await queue.queue_text_update(huge_text)
+    await queue.stop()
+
+    sent_payloads: list[str] = []
+    for call in client.chat_postMessage.await_args_list:
+        sent_payloads.append(call.kwargs.get("text", ""))
+    for call in client.chat_update.await_args_list:
+        sent_payloads.append(call.kwargs.get("text", ""))
+
+    assert sent_payloads, "expected at least one Slack send"
+    too_long = [len(p) for p in sent_payloads if len(p) > SLACK_MAX_MESSAGE_LENGTH]
+    assert not too_long, (
+        f"queue sent payloads exceeding Slack's text limit: {too_long}; "
+        f"limit={SLACK_MAX_MESSAGE_LENGTH}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_file_upload_proceeds_when_text_flush_fails_with_msg_too_long() -> None:
+    """
+    RED before fix: when a streamed text_buffer is too large, the pre-upload
+    chat.update flush in `_handle_file_upload` raises and the file upload
+    is abandoned — the user never receives the artifact.
+
+    GREEN after fix: the file upload still calls
+    files_getUploadURLExternal + files_completeUploadExternal even if the
+    text flush fails.
+    """
+    # Server only accepts payloads ≤ Slack's text limit.
+    client = _make_slack_client(fail_chat_update_when_over=SLACK_MAX_MESSAGE_LENGTH)
+    queue = _make_queue(client)
+    await queue.start()
+
+    # Seed an established streaming message so the text path uses chat.update.
+    queue.current_text_message_ts = "111.222"
+    queue.text_buffer = "y" * 60_000  # > 40K -> would trip msg_too_long server-side
+
+    # Now queue a real artifact (the mani report).  The pre-upload flush
+    # of the oversized buffer will be attempted; it must not block the
+    # file upload.
+    await queue.queue_file_upload(
+        filename="mani_notable_cases_report.md",
+        content_bytes=b"# Notable Support Cases - Mani\n" * 1000,
+        initial_comment="Attached file: mani_notable_cases_report.md",
+    )
+    await queue.stop()
+
+    assert client.files_getUploadURLExternal.await_count >= 1, (
+        "files_getUploadURLExternal was never called -- the file upload was "
+        "skipped because the pre-flush chat.update failed with msg_too_long"
+    )
+    assert client.files_completeUploadExternal.await_count >= 1, (
+        "files_completeUploadExternal was never called -- file upload incomplete"
+    )
+
+
+@pytest.mark.asyncio
+async def test_processor_keeps_running_after_msg_too_long_text_update(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    RED before fix: when chat.update fires msg_too_long during the StopSignal
+    final-flush, the exception escapes the per-op try/except and triggers the
+    outer "Fatal error in queue processor" path -- killing the queue.  Even
+    when the failure is during stop, we should not log "Fatal error", because
+    a permanent text-payload error must not be treated as a queue-fatal.
+
+    GREEN after fix: a `msg_too_long` from chat.update is treated as a
+    permanent, non-fatal failure (the message couldn't be updated, but the
+    processor should not log the outer "Fatal error" path).
+    """
+    import logging as _logging
+
+    client = _make_slack_client(fail_chat_update_when_over=SLACK_MAX_MESSAGE_LENGTH)
+    queue = _make_queue(client)
+
+    caplog.set_level(_logging.ERROR, logger="sam_slack_gateway_adapter.message_queue")
+
+    await queue.start()
+    # Stage state that triggers chat.update on stop with an oversized text.
+    queue.current_text_message_ts = "111.222"
+    queue.text_buffer = "z" * 60_000
+    await queue.stop()
+
+    fatal = [
+        r for r in caplog.records
+        if "Fatal error in queue processor" in r.getMessage()
+    ]
+    assert not fatal, (
+        "queue processor exited via the outer fatal-error path on a "
+        "msg_too_long flush -- it should treat that as a non-fatal "
+        "permanent error.  Log records:\n"
+        + "\n".join(r.getMessage() for r in fatal)
+    )


### PR DESCRIPTION
Streaming text could grow past Slack's 40K chat.update text limit (citation expansion + the 100K buffer cap). The resulting `msg_too_long` (a) crashed the queue processor via the StopSignal flush, and (b) aborted file-upload handling before files_getUploadURLExternal was called -- so artifacts like deep-research reports never reached the user.

- Truncate formatted text to SLACK_MAX_MESSAGE_LENGTH (40_000) before every chat.postMessage / chat.update; keep the tail with a short indicator.
- Lower _text_buffer_max_size from 100_000 to SLACK_MAX_MESSAGE_LENGTH and fix the misleading comment.
- Wrap the pre-upload text flush in _handle_file_upload in try/except so a failed flush can never abort the file upload.
- Wrap the StopSignal flush in _process_queue in try/except so a flush failure doesn't trigger the outer "Fatal error in queue processor" path.

Adds tests/unit/test_message_queue_msg_too_long.py covering all three contracts (red before fix, green after).