### PR TITLE
fix(DATAGO-133921): bump lxml for sam-rag

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(python -m py_compile:*)",
-      "Bash(rtk grep *)",
-      "Read(//Users/rudraneelchakraborty/Documents/work/projects/ai/solace-agent-mesh/**)"
-    ]
-  }
-}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,9 @@
 {
   "permissions": {
     "allow": [
-      "Bash(python -m py_compile:*)"
+      "Bash(python -m py_compile:*)",
+      "Bash(rtk grep *)",
+      "Read(//Users/rudraneelchakraborty/Documents/work/projects/ai/solace-agent-mesh/**)"
     ]
   }
 }

--- a/sam-rag/pyproject.toml
+++ b/sam-rag/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "beautifulsoup4==4.13.5",  # For HTML processing
     "pandas==2.3.2",  # For Excel processing
     "odfpy==1.4.1",  # For ODT processing
-    "lxml==6.0.1",  # XML parser for BeautifulSoup
+    "lxml==6.1.0",  # XML parser for BeautifulSoup
     "PyYAML==6.0.2",  # For YAML processing
     "qdrant-client==1.13.3",  # For Qdrant vector database access
     "watchdog==6.0.0",  # Fixed syntax for watchdog dependency


### PR DESCRIPTION
### What is the purpose of this change?                                                                                                                                   
  Fixes CVE-2026-41066 by bumping `lxml` from `6.0.1` to `6.1.0` in `sam-rag`.                                                                                              
                                                                                                                                                                            
  ### How was this change implemented?
  Single version bump in `sam-rag/pyproject.toml`.                                                                                                                          
                                                                                                                                                                            
  ### Key Design Decisions
  Pinned to exact version `6.1.0` (lowest safe) for reproducible builds, consistent with repo convention.                                                                   
                  
  ### How was this change tested?
  - [ ] Manual testing: none required — version constraint change only
  - [ ] Unit tests: no changes                                                                                                                                              
  - [ ] Integration tests: n/a
  - [ ] Known limitations: none                                                                                                                                             
                  
  ### Is there anything the reviewers should focus on/be aware of?
  Straightforward security pin bump, no logic changes.