### PR TITLE
fix(DATAGO-134417): bump pydantic to 2.12.5 in core plugins for litel…

### DIFF
--- a/sam-mongodb/pyproject.toml
+++ b/sam-mongodb/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "pymongo==4.15.1",
-    "pydantic==2.11.9",
+    "pydantic==2.12.5",  # bumped from 2.11.9 — required by litellm==1.83.14 (via solace-agent-mesh)
     "PyYAML==6.0.2"
 ]
 

--- a/sam-sql-database-tool/pyproject.toml
+++ b/sam-sql-database-tool/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "psycopg2-binary==2.9.10",
   "pyodbc==5.3.0",
   "oracledb==3.4.1",
-  "pydantic==2.11.9",
+  "pydantic==2.12.5",  # bumped from 2.11.9 — required by litellm==1.83.14 (via solace-agent-mesh)
   "PyYAML==6.0.2"
 ]
 

--- a/sam-sql-database/pyproject.toml
+++ b/sam-sql-database/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "SQLAlchemy==2.0.40",
     "PyMySQL==1.1.2",
     "psycopg2-binary==2.9.10",
-    "pydantic==2.11.9",
+    "pydantic==2.12.5",  # bumped from 2.11.9 — required by litellm==1.83.14 (via solace-agent-mesh)
     "PyYAML==6.0.2"
 ]
 


### PR DESCRIPTION

### What is the purpose of this change?

Bumps pydantic==2.11.9 to 2.12.5 in 3 core plugins to resolve a dependency conflict introduced by the litellm security upgrade in solace-agent-mesh.  

### How was this change implemented?

 Updated pydantic in sam-sql-database, sam-sql-database-tool, and sam-mongodb. Depends on the solace-agent-mesh pydantic bump landing first. 

### Key Design Decisions _(optional - delete if not applicable)_

NA

### How was this change tested?

- [ ] Manual testing: [describe scenarios]
- [ ] Unit tests: [new/modified tests]
- [ ] Integration tests: [if applicable]
- [ ] Known limitations: [what wasn't tested]

### Is there anything the reviewers should focus on/be aware of?

    Special attention areas, potential risks, or open questions
