### PR TITLE
fix(DATAGO-135081): bump deps for critical/high vuln fixes

### DIFF
--- a/sam-mcp-server-gateway-adapter/pyproject.toml
+++ b/sam-mcp-server-gateway-adapter/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 dependencies = [
-    "fastmcp>=2.14.2",
+    "fastmcp>=3.2.0",
     "starlette~=0.49.1",
     "httpx>=0.27.0",
 ]

--- a/sam-mongodb/pyproject.toml
+++ b/sam-mongodb/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "pymongo==4.15.1",
-    "pydantic==2.11.9",
+    "pydantic==2.12.5",
     "PyYAML==6.0.2"
 ]
 

--- a/sam-sql-database-tool/pyproject.toml
+++ b/sam-sql-database-tool/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   "psycopg2-binary==2.9.10",
   "pyodbc==5.3.0",
   "oracledb==3.4.1",
-  "pydantic==2.11.9",
+  "pydantic==2.12.5",
   "PyYAML==6.0.2"
 ]
 

--- a/sam-sql-database/pyproject.toml
+++ b/sam-sql-database/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "SQLAlchemy==2.0.40",
     "PyMySQL==1.1.2",
     "psycopg2-binary==2.9.10",
-    "pydantic==2.11.9",
+    "pydantic==2.12.5",
     "PyYAML==6.0.2"
 ]
 


### PR DESCRIPTION
## Summary
- Bump `fastmcp` floor from `>=2.14.2` to `>=3.2.0` in sam-mcp-server-gateway-adapter (CVE-2026-32871, CRITICAL)
- Bump `pydantic` from `2.11.9` to `2.12.5` in sam-sql-database, sam-sql-database-tool, and sam-mongodb (required by litellm>=1.83.7 cascade)

## Test plan
- [x] sam-mcp-server-gateway-adapter: 23/23 tests pass
- [x] sam-sql-database-tool: 77/77 tests pass
- [x] sam-mongodb: 12/12 tests pass
- [x] sam-sql-database: install succeeds (placeholder tests only)
- [x] Clean venv install with SAM + enterprise: all imports OK

> **Merge order:** This PR should be merged **first** (before solace-ai-connector, solace-agent-mesh, and enterprise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)