### PR TITLE
fix(DATAGO-144731): widen sam-mcp-server-gateway-adapter starlette range to <2

### DIFF
--- a/sam-mcp-server-gateway-adapter/pyproject.toml
+++ b/sam-mcp-server-gateway-adapter/pyproject.toml
@@ -29,7 +29,9 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=3.2.0",
-    "starlette~=0.49.1",
+    # Spans 0.49 (solace-agent-mesh 1.x) and 1.x (solace-agent-mesh with the
+    # starlette CVE fixes); only stable APIs (Route, responses) are used here.
+    "starlette>=0.49.1,<2",
     "httpx>=0.27.0",
 ]
 


### PR DESCRIPTION
## Summary
Part of the [DATAGO-144731](https://sol-jira.atlassian.net/browse/DATAGO-144731) starlette CVE chain: `starlette~=0.49.1` caps consumers below 0.50, which blocks the enterprise repo from taking the starlette 1.3.1 security fixes (CVE-2026-48710/-48817/-48818/-54282/-54283) once solace-agent-mesh moves to starlette 1.x (SolaceLabs/solace-agent-mesh#1602, google-adk 2.5.0 migration — CI green).

## Change
One line: `starlette~=0.49.1` → `starlette>=0.49.1,<2`.

The widened range spans both lines deliberately:
- **0.49.x** — today's solace-agent-mesh 1.28.4, so releasing this adapter changes nothing for current consumers
- **1.x** — the upgraded community/enterprise stack, unblocking the enterprise upversion

The adapter only touches stable starlette APIs (`Route`, `JSONResponse`, `RedirectResponse`), which are unchanged across 0.49 → 1.3.

## Sequencing
After merge, a release (0.1.3) is needed so the enterprise repo can pin it alongside the upgraded solace-agent-mesh — it's the last constraint forbidding starlette 1.x in the enterprise lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DATAGO-144731]: https://sol-jira.atlassian.net/browse/DATAGO-144731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ