### PR TITLE
fix(DATAGO-146034): Cache PowerBI tokens per user

### DIFF
--- a/sam-powerbi/README.md
+++ b/sam-powerbi/README.md
@@ -34,7 +34,7 @@ export AZURE_TENANT_ID="your azure tenant id"
 export POWERBI_CLIENT_ID="your powerBI client id"
 export POWERBI_WORKSPACE_ID="your powerBI workspace id"
 export POWERBI_SEMANTIC_MODEL_ID="your semantic model id"
-export POWERBI_TOKEN_CACHE="your location for your token-cahe, default /tmp/samv2/powerbi_msal_cache.json"
+export POWERBI_TOKEN_CACHE="your location for your token-cahe, default ~/.cache/samv2/powerbi_msal_cache.json"
 ```
 
 ## Build

--- a/sam-powerbi/pyproject.toml
+++ b/sam-powerbi/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "msal>=1.34",
     "httpx>=0.27",
+    "anyio>=4.0",
 ]
 
 [project.urls]

--- a/sam-powerbi/src/sam_powerbi/auth.py
+++ b/sam-powerbi/src/sam_powerbi/auth.py
@@ -71,7 +71,7 @@ class PowerBIAuth:
         self,
         tenant_id: str,
         client_id: str,
-        token_cache_path: str = "/tmp/samv2/powerbi_msal_cache.json",
+        token_cache_path: str = os.path.expanduser("~/.cache/samv2/powerbi_msal_cache.json"),
     ):
         if not tenant_id:
             raise ValueError("tenant_id is required for PowerBIAuth")

--- a/sam-powerbi/src/sam_powerbi/auth.py
+++ b/sam-powerbi/src/sam_powerbi/auth.py
@@ -60,8 +60,10 @@ class PowerBIAuth:
     """
     Manages delegated PowerBI OAuth tokens via MSAL device-code flow.
 
-    One instance per (tenant_id, client_id, token_cache_path) tuple. Safe
-    for concurrent tool calls — all state transitions go through
+    One instance per (tenant_id, client_id, token_cache_path) tuple. Callers
+    (see tools._get_auth) derive a distinct token_cache_path per SAM user, so
+    in practice this means one instance — and one cached account — per user.
+    Safe for concurrent tool calls — all state transitions go through
     ``_token_lock``.
     """
 
@@ -123,6 +125,8 @@ class PowerBIAuth:
         accounts = self._app.get_accounts()
         if not accounts:
             return None
+        # token_cache_path is per-user (see tools._user_cache_path), so this
+        # cache holds exactly one account — accounts[0] is unambiguous.
         result = self._app.acquire_token_silent([POWERBI_SCOPE], account=accounts[0])
         if result and "access_token" in result:
             self._save_cache()

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -197,7 +197,7 @@ async def _send_query_with_reauth(
         f" (X-PowerBI-Error-Info: {error_info})" if error_info else "",
     )
     auth.force_reauth()
-    token, err = _get_token(auth, "Re-auth failed")
+    new_token, err = _get_token(auth, "Re-auth failed")
     if err:
         if error_info:
             err["message"] = (
@@ -209,7 +209,7 @@ async def _send_query_with_reauth(
             err["powerbi_error_info"] = error_info
         return None, err
 
-    resp = await _post(token)
+    resp = await _post(new_token)
     if resp.status_code == 401:
         error_info = _powerbi_error_info(resp)
         logger.warning(

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -32,6 +32,7 @@ import os
 import threading
 from typing import Any, Dict, Optional
 
+import anyio
 import httpx
 from google.adk.tools import ToolContext
 
@@ -177,15 +178,16 @@ async def _send_query_with_reauth(
     """
 
     async def _post(bearer: str) -> httpx.Response:
-        async with httpx.AsyncClient(timeout=timeout) as client_http:
-            return await client_http.post(
-                endpoint,
-                headers={
-                    "Authorization": f"Bearer {bearer}",
-                    "Content-Type": "application/json",
-                },
-                json=body,
-            )
+        async with httpx.AsyncClient(timeout=None) as client_http:
+            with anyio.fail_after(timeout):
+                return await client_http.post(
+                    endpoint,
+                    headers={
+                        "Authorization": f"Bearer {bearer}",
+                        "Content-Type": "application/json",
+                    },
+                    json=body,
+                )
 
     resp = await _post(token)
     if resp.status_code != 401:
@@ -411,7 +413,7 @@ async def execute_powerbi_query(
 
         return _dispatch_response(resp)
 
-    except httpx.TimeoutException:
+    except (httpx.TimeoutException, TimeoutError):
         return {
             "status": "error",
             "error_code": "TIMEOUT",

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -13,11 +13,22 @@ tool_config (populated from the agent YAML ``tool_config:`` block):
     rest_timeout_seconds: per-request HTTP timeout (default 30)
     token_cache_path: MSAL serializable cache file path
                       (default /tmp/samv2/powerbi_msal_cache.json)
+
+Each SAM user gets their own delegated PowerBI token, cached in its own
+file derived from ``token_cache_path`` and the caller's ``user_id`` (from
+``tool_context.invocation_context.user_id``). This isolation is only as
+good as the gateway's identity: it requires the gateway to supply a real
+per-human user_id (e.g. Slack does this by default; REST/webhook/event-mesh
+gateways only do so if authentication is enforced and configured with a
+per-user claim — otherwise every caller collapses onto the same generic
+identity and shares one cached token). Check your gateway's auth config.
 """
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import os
 import threading
 from typing import Any, Dict, Optional
 
@@ -34,11 +45,20 @@ logger = logging.getLogger(__name__)
 
 POWERBI_REST_BASE = "https://api.powerbi.com/v1.0/myorg"
 
-# One PowerBIAuth per (tenant, client, cache_path) tuple. Built lazily on
-# first tool call so that a SAM install missing PowerBI env vars still
-# starts up cleanly and only fails when the tool is actually invoked.
+ANONYMOUS_USER_ID = "anonymous"
+
+# One PowerBIAuth per (tenant, client, per-user cache_path) tuple. Built
+# lazily on first tool call so that a SAM install missing PowerBI env vars
+# still starts up cleanly and only fails when the tool is actually invoked.
 _auth_cache: Dict[tuple, PowerBIAuth] = {}
 _auth_lock = threading.Lock()
+
+
+def _user_cache_path(base_path: str, user_id: str) -> str:
+    """Derive a per-user MSAL cache file path from the configured base path."""
+    root, ext = os.path.splitext(base_path)
+    user_key = hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:16]
+    return f"{root}.{user_key}{ext}"
 
 
 def _require(cfg: Dict[str, Any], key: str) -> str:
@@ -50,10 +70,11 @@ def _require(cfg: Dict[str, Any], key: str) -> str:
     return str(val)
 
 
-def _get_auth(cfg: Dict[str, Any]) -> PowerBIAuth:
+def _get_auth(cfg: Dict[str, Any], user_id: str) -> PowerBIAuth:
     tenant = _require(cfg, "tenant_id")
     client = _require(cfg, "client_id")
-    cache_path = cfg.get("token_cache_path") or "/tmp/samv2/powerbi_msal_cache.json"
+    base_path = cfg.get("token_cache_path") or "/tmp/samv2/powerbi_msal_cache.json"
+    cache_path = _user_cache_path(base_path, user_id)
     key = (tenant, client, cache_path)
     with _auth_lock:
         auth = _auth_cache.get(key)
@@ -246,7 +267,12 @@ async def execute_powerbi_query(
     if err:
         return err
 
-    auth = _get_auth(cfg)
+    user_id = (
+        tool_context.invocation_context.user_id
+        if tool_context is not None
+        else ANONYMOUS_USER_ID
+    )
+    auth = _get_auth(cfg, user_id)
     token, err = _get_token(auth, "Failed to acquire PowerBI token")
     if err:
         return err

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -328,6 +328,16 @@ def _validate_dax(dax_query: str) -> tuple[Optional[str], Optional[Dict[str, Any
     return dax, None
 
 
+def _resolve_user_id(tool_context: Optional[ToolContext]) -> str:
+    """Resolve the per-user cache key from tool_context, falling back to a shared anonymous identity."""
+    if tool_context is None:
+        logger.warning(
+            "[sam_powerbi] No tool_context — falling back to shared anonymous cache; per-user isolation is disabled"
+        )
+        return ANONYMOUS_USER_ID
+    return tool_context.session.user_id
+
+
 def _validate_request_config(cfg: Dict[str, Any]) -> tuple[Optional[tuple[str, str, float]], Optional[Dict[str, Any]]]:
     """Validate tool_config. Returns ((workspace_id, dataset_id, timeout), None) or (None, error_dict)."""
     try:
@@ -382,11 +392,7 @@ async def execute_powerbi_query(
     if err:
         return err
 
-    if tool_context is None:
-        logger.warning("[sam_powerbi] No tool_context — falling back to shared anonymous cache; per-user isolation is disabled")
-        user_id = ANONYMOUS_USER_ID
-    else:
-        user_id = tool_context.session.user_id
+    user_id = _resolve_user_id(tool_context)
 
     auth = _get_auth(cfg, user_id)
     token, err = _get_token(auth, "Failed to acquire PowerBI token")

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -130,6 +130,16 @@ def _format_results_markdown(payload: Dict[str, Any], max_rows: int = 100) -> Di
     }
 
 
+def _powerbi_error_info(resp: httpx.Response) -> Optional[str]:
+    """Extract PowerBI's own diagnostic header, when present.
+
+    PowerBI's REST API often explains *why* a request failed (expired token,
+    missing consent, no workspace access, etc.) in this header even when the
+    HTTP status code alone (e.g. a bare 401) doesn't say.
+    """
+    return resp.headers.get("X-PowerBI-Error-Info") or None
+
+
 def _auth_required_response(pending: PowerBIAuthPending) -> Dict[str, Any]:
     return {
         "status": "error",
@@ -298,12 +308,34 @@ async def execute_powerbi_query(
         resp = await _post(token)
 
         if resp.status_code == 401:
-            logger.info("[sam_powerbi] 401 — forcing re-authentication")
+            error_info = _powerbi_error_info(resp)
+            logger.info(
+                "[sam_powerbi] 401 — forcing re-authentication%s",
+                f" (X-PowerBI-Error-Info: {error_info})" if error_info else "",
+            )
             auth.force_reauth()
             token, err = _get_token(auth, "Re-auth failed")
             if err:
                 return err
             resp = await _post(token)
+
+            if resp.status_code == 401:
+                error_info = _powerbi_error_info(resp)
+                logger.warning(
+                    "[sam_powerbi] Still 401 after re-authentication%s",
+                    f" — X-PowerBI-Error-Info: {error_info}" if error_info else "",
+                )
+                return {
+                    "status": "error",
+                    "error_code": "AUTH_ERROR",
+                    "message": (
+                        "PowerBI rejected the freshly-acquired token (401 persists after "
+                        "re-authentication). This usually means the AAD app registration is "
+                        "missing consented PowerBI API permissions, or the signed-in user "
+                        "lacks access to this workspace/dataset."
+                        + (f" PowerBI-Error-Info: {error_info}" if error_info else "")
+                    ),
+                }
 
         if resp.status_code == 200:
             return _handle_200_response(resp)
@@ -311,16 +343,24 @@ async def execute_powerbi_query(
             return _handle_400_response(resp)
         if resp.status_code == 429:
             retry_after = resp.headers.get("Retry-After", "unknown")
+            error_info = _powerbi_error_info(resp)
             return {
                 "status": "error",
                 "error_code": "RATE_LIMIT",
-                "message": f"PowerBI REST API rate limit exceeded (Retry-After: {retry_after}s). Wait before retrying.",
+                "message": (
+                    f"PowerBI REST API rate limit exceeded (Retry-After: {retry_after}s). Wait before retrying."
+                    + (f" X-PowerBI-Error-Info: {error_info}" if error_info else "")
+                ),
                 "retry_after": retry_after,
             }
+        error_info = _powerbi_error_info(resp)
         return {
             "status": "error",
             "error_code": "REST_ERROR",
-            "message": f"HTTP {resp.status_code}: {resp.text[:500]}",
+            "message": (
+                f"HTTP {resp.status_code}: {resp.text[:500]}"
+                + (f" | X-PowerBI-Error-Info: {error_info}" if error_info else "")
+            ),
             "http_status": resp.status_code,
         }
 

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -231,6 +231,20 @@ def _validate_dax(dax_query: str) -> tuple[Optional[str], Optional[Dict[str, Any
     return dax, None
 
 
+def _validate_request_config(cfg: Dict[str, Any]) -> tuple[Optional[tuple[str, str, float]], Optional[Dict[str, Any]]]:
+    """Validate tool_config. Returns ((workspace_id, dataset_id, timeout), None) or (None, error_dict)."""
+    try:
+        _require(cfg, "tenant_id")
+        _require(cfg, "client_id")
+        workspace_id = _require(cfg, "workspace_id")
+        dataset_id = _require(cfg, "dataset_id")
+    except ValueError as e:
+        logger.error("[sam_powerbi] %s", e)
+        return None, {"status": "error", "error_code": "CONFIG_ERROR", "message": str(e)}
+    timeout = float(cfg.get("rest_timeout_seconds") or 30)
+    return (workspace_id, dataset_id, timeout), None
+
+
 async def execute_powerbi_query(
     dax_query: str,
     tool_context: Optional[ToolContext] = None,
@@ -262,16 +276,10 @@ async def execute_powerbi_query(
     """
     cfg = tool_config or {}
 
-    try:
-        _require(cfg, "tenant_id")
-        _require(cfg, "client_id")
-        workspace_id = _require(cfg, "workspace_id")
-        dataset_id = _require(cfg, "dataset_id")
-    except ValueError as e:
-        logger.error("[sam_powerbi] %s", e)
-        return {"status": "error", "error_code": "CONFIG_ERROR", "message": str(e)}
-
-    timeout = float(cfg.get("rest_timeout_seconds") or 30)
+    config, err = _validate_request_config(cfg)
+    if err:
+        return err
+    workspace_id, dataset_id, timeout = config
 
     dax, err = _validate_dax(dax_query)
     if err:

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -16,7 +16,7 @@ tool_config (populated from the agent YAML ``tool_config:`` block):
 
 Each SAM user gets their own delegated PowerBI token, cached in its own
 file derived from ``token_cache_path`` and the caller's ``user_id`` (from
-``tool_context.invocation_context.user_id``). This isolation is only as
+``tool_context.session.user_id``). This isolation is only as
 good as the gateway's identity: it requires the gateway to supply a real
 per-human user_id (e.g. Slack does this by default; REST/webhook/event-mesh
 gateways only do so if authentication is enforced and configured with a
@@ -268,7 +268,7 @@ async def execute_powerbi_query(
         return err
 
     user_id = (
-        tool_context.invocation_context.user_id
+        tool_context.session.user_id
         if tool_context is not None
         else ANONYMOUS_USER_ID
     )

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -281,9 +281,9 @@ def _dispatch_response(resp: httpx.Response) -> Dict[str, Any]:
         return _handle_200_response(resp)
     if resp.status_code == 400:
         return _handle_400_response(resp)
+    error_info = _powerbi_error_info(resp)
     if resp.status_code == 429:
         retry_after = resp.headers.get("Retry-After", "unknown")
-        error_info = _powerbi_error_info(resp)
         return {
             "status": "error",
             "error_code": "RATE_LIMIT",
@@ -294,7 +294,6 @@ def _dispatch_response(resp: httpx.Response) -> Dict[str, Any]:
             "retry_after": retry_after,
             "powerbi_error_info": error_info,
         }
-    error_info = _powerbi_error_info(resp)
     return {
         "status": "error",
         "error_code": "REST_ERROR",

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -316,6 +316,14 @@ async def execute_powerbi_query(
             auth.force_reauth()
             token, err = _get_token(auth, "Re-auth failed")
             if err:
+                if error_info:
+                    err["message"] = (
+                        f"PowerBI rejected the previous token (X-PowerBI-Error-Info: "
+                        f"{error_info}) before this new sign-in was requested — signing in "
+                        f"again will not help if that reason is a permissions/access issue "
+                        f"rather than an expired token. {err['message']}"
+                    )
+                    err["powerbi_error_info"] = error_info
                 return err
             resp = await _post(token)
 
@@ -335,6 +343,7 @@ async def execute_powerbi_query(
                         "lacks access to this workspace/dataset."
                         + (f" PowerBI-Error-Info: {error_info}" if error_info else "")
                     ),
+                    "powerbi_error_info": error_info,
                 }
 
         if resp.status_code == 200:
@@ -352,6 +361,7 @@ async def execute_powerbi_query(
                     + (f" X-PowerBI-Error-Info: {error_info}" if error_info else "")
                 ),
                 "retry_after": retry_after,
+                "powerbi_error_info": error_info,
             }
         error_info = _powerbi_error_info(resp)
         return {
@@ -362,6 +372,7 @@ async def execute_powerbi_query(
                 + (f" | X-PowerBI-Error-Info: {error_info}" if error_info else "")
             ),
             "http_status": resp.status_code,
+            "powerbi_error_info": error_info,
         }
 
     except httpx.TimeoutException:

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -275,6 +275,38 @@ def _handle_400_response(resp: httpx.Response) -> Dict[str, Any]:
         return {"status": "error", "error_code": "DAX_ERROR", "message": resp.text[:500]}
 
 
+def _dispatch_response(resp: httpx.Response) -> Dict[str, Any]:
+    """Map a non-retried HTTP response to the tool's result dict, by status code."""
+    if resp.status_code == 200:
+        return _handle_200_response(resp)
+    if resp.status_code == 400:
+        return _handle_400_response(resp)
+    if resp.status_code == 429:
+        retry_after = resp.headers.get("Retry-After", "unknown")
+        error_info = _powerbi_error_info(resp)
+        return {
+            "status": "error",
+            "error_code": "RATE_LIMIT",
+            "message": (
+                f"PowerBI REST API rate limit exceeded (Retry-After: {retry_after}s). Wait before retrying."
+                + (f" X-PowerBI-Error-Info: {error_info}" if error_info else "")
+            ),
+            "retry_after": retry_after,
+            "powerbi_error_info": error_info,
+        }
+    error_info = _powerbi_error_info(resp)
+    return {
+        "status": "error",
+        "error_code": "REST_ERROR",
+        "message": (
+            f"HTTP {resp.status_code}: {resp.text[:500]}"
+            + (f" | X-PowerBI-Error-Info: {error_info}" if error_info else "")
+        ),
+        "http_status": resp.status_code,
+        "powerbi_error_info": error_info,
+    }
+
+
 def _validate_dax(dax_query: str) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
     """Validate and normalise a DAX query. Returns (dax, None) or (None, error_dict)."""
     if not dax_query or not dax_query.strip():
@@ -372,34 +404,7 @@ async def execute_powerbi_query(
         if err:
             return err
 
-        if resp.status_code == 200:
-            return _handle_200_response(resp)
-        if resp.status_code == 400:
-            return _handle_400_response(resp)
-        if resp.status_code == 429:
-            retry_after = resp.headers.get("Retry-After", "unknown")
-            error_info = _powerbi_error_info(resp)
-            return {
-                "status": "error",
-                "error_code": "RATE_LIMIT",
-                "message": (
-                    f"PowerBI REST API rate limit exceeded (Retry-After: {retry_after}s). Wait before retrying."
-                    + (f" X-PowerBI-Error-Info: {error_info}" if error_info else "")
-                ),
-                "retry_after": retry_after,
-                "powerbi_error_info": error_info,
-            }
-        error_info = _powerbi_error_info(resp)
-        return {
-            "status": "error",
-            "error_code": "REST_ERROR",
-            "message": (
-                f"HTTP {resp.status_code}: {resp.text[:500]}"
-                + (f" | X-PowerBI-Error-Info: {error_info}" if error_info else "")
-            ),
-            "http_status": resp.status_code,
-            "powerbi_error_info": error_info,
-        }
+        return _dispatch_response(resp)
 
     except httpx.TimeoutException:
         return {

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -166,6 +166,71 @@ def _get_token(
         return None, {"status": "error", "error_code": "AUTH_ERROR", "message": f"{error_prefix}: {e}"}
 
 
+async def _send_query_with_reauth(
+    auth: PowerBIAuth, endpoint: str, body: Dict[str, Any], token: str, timeout: float
+) -> tuple[Optional[httpx.Response], Optional[Dict[str, Any]]]:
+    """POST the query; on 401, force reauth and retry once.
+
+    Returns (response, None) on any non-terminal outcome (including a second
+    401 that the caller's status dispatch will report), or (None, error_dict)
+    if reauth itself failed.
+    """
+
+    async def _post(bearer: str) -> httpx.Response:
+        async with httpx.AsyncClient(timeout=timeout) as client_http:
+            return await client_http.post(
+                endpoint,
+                headers={
+                    "Authorization": f"Bearer {bearer}",
+                    "Content-Type": "application/json",
+                },
+                json=body,
+            )
+
+    resp = await _post(token)
+    if resp.status_code != 401:
+        return resp, None
+
+    error_info = _powerbi_error_info(resp)
+    logger.info(
+        "[sam_powerbi] 401 — forcing re-authentication%s",
+        f" (X-PowerBI-Error-Info: {error_info})" if error_info else "",
+    )
+    auth.force_reauth()
+    token, err = _get_token(auth, "Re-auth failed")
+    if err:
+        if error_info:
+            err["message"] = (
+                f"PowerBI rejected the previous token (X-PowerBI-Error-Info: "
+                f"{error_info}) before this new sign-in was requested — signing in "
+                f"again will not help if that reason is a permissions/access issue "
+                f"rather than an expired token. {err['message']}"
+            )
+            err["powerbi_error_info"] = error_info
+        return None, err
+
+    resp = await _post(token)
+    if resp.status_code == 401:
+        error_info = _powerbi_error_info(resp)
+        logger.warning(
+            "[sam_powerbi] Still 401 after re-authentication%s",
+            f" — X-PowerBI-Error-Info: {error_info}" if error_info else "",
+        )
+        return None, {
+            "status": "error",
+            "error_code": "AUTH_ERROR",
+            "message": (
+                "PowerBI rejected the freshly-acquired token (401 persists after "
+                "re-authentication). This usually means the AAD app registration is "
+                "missing consented PowerBI API permissions, or the signed-in user "
+                "lacks access to this workspace/dataset."
+                + (f" PowerBI-Error-Info: {error_info}" if error_info else "")
+            ),
+            "powerbi_error_info": error_info,
+        }
+    return resp, None
+
+
 def _handle_200_response(resp: httpx.Response) -> Dict[str, Any]:
     """Parse and format a 200 executeQueries response."""
     try:
@@ -302,58 +367,10 @@ async def execute_powerbi_query(
         "serializerSettings": {"includeNulls": True},
     }
 
-    async def _post(bearer: str) -> httpx.Response:
-        async with httpx.AsyncClient(timeout=timeout) as client_http:
-            return await client_http.post(
-                endpoint,
-                headers={
-                    "Authorization": f"Bearer {bearer}",
-                    "Content-Type": "application/json",
-                },
-                json=body,
-            )
-
     try:
-        resp = await _post(token)
-
-        if resp.status_code == 401:
-            error_info = _powerbi_error_info(resp)
-            logger.info(
-                "[sam_powerbi] 401 — forcing re-authentication%s",
-                f" (X-PowerBI-Error-Info: {error_info})" if error_info else "",
-            )
-            auth.force_reauth()
-            token, err = _get_token(auth, "Re-auth failed")
-            if err:
-                if error_info:
-                    err["message"] = (
-                        f"PowerBI rejected the previous token (X-PowerBI-Error-Info: "
-                        f"{error_info}) before this new sign-in was requested — signing in "
-                        f"again will not help if that reason is a permissions/access issue "
-                        f"rather than an expired token. {err['message']}"
-                    )
-                    err["powerbi_error_info"] = error_info
-                return err
-            resp = await _post(token)
-
-            if resp.status_code == 401:
-                error_info = _powerbi_error_info(resp)
-                logger.warning(
-                    "[sam_powerbi] Still 401 after re-authentication%s",
-                    f" — X-PowerBI-Error-Info: {error_info}" if error_info else "",
-                )
-                return {
-                    "status": "error",
-                    "error_code": "AUTH_ERROR",
-                    "message": (
-                        "PowerBI rejected the freshly-acquired token (401 persists after "
-                        "re-authentication). This usually means the AAD app registration is "
-                        "missing consented PowerBI API permissions, or the signed-in user "
-                        "lacks access to this workspace/dataset."
-                        + (f" PowerBI-Error-Info: {error_info}" if error_info else "")
-                    ),
-                    "powerbi_error_info": error_info,
-                }
+        resp, err = await _send_query_with_reauth(auth, endpoint, body, token, timeout)
+        if err:
+            return err
 
         if resp.status_code == 200:
             return _handle_200_response(resp)

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -168,26 +168,26 @@ def _get_token(
 
 
 async def _send_query_with_reauth(
-    auth: PowerBIAuth, endpoint: str, body: Dict[str, Any], token: str, timeout: float
+    auth: PowerBIAuth, endpoint: str, body: Dict[str, Any], token: str
 ) -> tuple[Optional[httpx.Response], Optional[Dict[str, Any]]]:
     """POST the query; on 401, force reauth and retry once.
 
     Returns (response, None) on any non-terminal outcome (including a second
     401 that the caller's status dispatch will report), or (None, error_dict)
-    if reauth itself failed.
+    if reauth itself failed. The caller is expected to bound the whole call
+    with a timeout context manager (e.g. anyio.fail_after).
     """
 
     async def _post(bearer: str) -> httpx.Response:
         async with httpx.AsyncClient(timeout=None) as client_http:
-            with anyio.fail_after(timeout):
-                return await client_http.post(
-                    endpoint,
-                    headers={
-                        "Authorization": f"Bearer {bearer}",
-                        "Content-Type": "application/json",
-                    },
-                    json=body,
-                )
+            return await client_http.post(
+                endpoint,
+                headers={
+                    "Authorization": f"Bearer {bearer}",
+                    "Content-Type": "application/json",
+                },
+                json=body,
+            )
 
     resp = await _post(token)
     if resp.status_code != 401:
@@ -407,7 +407,8 @@ async def execute_powerbi_query(
     }
 
     try:
-        resp, err = await _send_query_with_reauth(auth, endpoint, body, token, timeout)
+        with anyio.fail_after(timeout):
+            resp, err = await _send_query_with_reauth(auth, endpoint, body, token)
         if err:
             return err
 

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -277,11 +277,12 @@ async def execute_powerbi_query(
     if err:
         return err
 
-    user_id = (
-        tool_context.session.user_id
-        if tool_context is not None
-        else ANONYMOUS_USER_ID
-    )
+    if tool_context is None:
+        logger.warning("[sam_powerbi] No tool_context — falling back to shared anonymous cache; per-user isolation is disabled")
+        user_id = ANONYMOUS_USER_ID
+    else:
+        user_id = tool_context.session.user_id
+
     auth = _get_auth(cfg, user_id)
     token, err = _get_token(auth, "Failed to acquire PowerBI token")
     if err:

--- a/sam-powerbi/src/sam_powerbi/tools.py
+++ b/sam-powerbi/src/sam_powerbi/tools.py
@@ -12,7 +12,7 @@ tool_config (populated from the agent YAML ``tool_config:`` block):
     dataset_id: PowerBI semantic-model GUID (required)
     rest_timeout_seconds: per-request HTTP timeout (default 30)
     token_cache_path: MSAL serializable cache file path
-                      (default /tmp/samv2/powerbi_msal_cache.json)
+                      (default ~/.cache/samv2/powerbi_msal_cache.json)
 
 Each SAM user gets their own delegated PowerBI token, cached in its own
 file derived from ``token_cache_path`` and the caller's ``user_id`` (from
@@ -73,7 +73,7 @@ def _require(cfg: Dict[str, Any], key: str) -> str:
 def _get_auth(cfg: Dict[str, Any], user_id: str) -> PowerBIAuth:
     tenant = _require(cfg, "tenant_id")
     client = _require(cfg, "client_id")
-    base_path = cfg.get("token_cache_path") or "/tmp/samv2/powerbi_msal_cache.json"
+    base_path = cfg.get("token_cache_path") or os.path.expanduser("~/.cache/samv2/powerbi_msal_cache.json")
     cache_path = _user_cache_path(base_path, user_id)
     key = (tenant, client, cache_path)
     with _auth_lock:

--- a/sam-powerbi/tests/unit/test_tools.py
+++ b/sam-powerbi/tests/unit/test_tools.py
@@ -447,6 +447,49 @@ class TestAuthFlow:
         assert r["error_code"] == "AUTH_ERROR"
         assert "re-auth failed" in r["message"]
 
+    @pytest.mark.asyncio
+    async def test_persistent_401_surfaces_powerbi_error_info(self):
+        resp_401 = _mock_http(
+            401, text="Unauthorized", headers={"X-PowerBI-Error-Info": "TokenExpired"}
+        )
+
+        with patch("sam_powerbi.tools._get_auth") as m:
+            auth = MagicMock()
+            auth.get_token_or_start_device_flow.return_value = "token"
+            m.return_value = auth
+
+            with patch("httpx.AsyncClient") as mock_cls:
+                inst = AsyncMock()
+                inst.post.return_value = resp_401
+                mock_cls.return_value.__aenter__ = AsyncMock(return_value=inst)
+                mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+                r = await execute_powerbi_query("EVALUATE 'T'", tool_config=MINIMAL_CFG)
+
+        assert r["error_code"] == "AUTH_ERROR"
+        assert "TokenExpired" in r["message"]
+        auth.force_reauth.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_persistent_401_without_header_omits_error_info(self):
+        resp_401 = _mock_http(401, text="Unauthorized")
+
+        with patch("sam_powerbi.tools._get_auth") as m:
+            auth = MagicMock()
+            auth.get_token_or_start_device_flow.return_value = "token"
+            m.return_value = auth
+
+            with patch("httpx.AsyncClient") as mock_cls:
+                inst = AsyncMock()
+                inst.post.return_value = resp_401
+                mock_cls.return_value.__aenter__ = AsyncMock(return_value=inst)
+                mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+                r = await execute_powerbi_query("EVALUATE 'T'", tool_config=MINIMAL_CFG)
+
+        assert r["error_code"] == "AUTH_ERROR"
+        assert "PowerBI-Error-Info" not in r["message"]
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # execute_powerbi_query — HTTP response handling
@@ -566,6 +609,24 @@ class TestHTTPResponseHandling:
         assert r["retry_after"] == "60"
 
     @pytest.mark.asyncio
+    async def test_429_rate_limit_includes_powerbi_error_info_header(self):
+        resp = _mock_http(
+            429,
+            text="Too Many Requests",
+            headers={"Retry-After": "60", "X-PowerBI-Error-Info": "TooManyRequests"},
+        )
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            inst = AsyncMock()
+            inst.post.return_value = resp
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=inst)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            r = await execute_powerbi_query("EVALUATE 'T'", tool_config=MINIMAL_CFG)
+
+        assert r["error_code"] == "RATE_LIMIT"
+        assert "TooManyRequests" in r["message"]
+
+    @pytest.mark.asyncio
     async def test_503_rest_error(self):
         resp = _mock_http(503, text="Service Unavailable")
 
@@ -578,6 +639,24 @@ class TestHTTPResponseHandling:
 
         assert r["error_code"] == "REST_ERROR"
         assert "503" in r["message"]
+
+    @pytest.mark.asyncio
+    async def test_rest_error_includes_powerbi_error_info_header(self):
+        resp = _mock_http(
+            503,
+            text="Service Unavailable",
+            headers={"X-PowerBI-Error-Info": "InternalServerError"},
+        )
+
+        with patch("httpx.AsyncClient") as mock_cls:
+            inst = AsyncMock()
+            inst.post.return_value = resp
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=inst)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            r = await execute_powerbi_query("EVALUATE 'T'", tool_config=MINIMAL_CFG)
+
+        assert r["error_code"] == "REST_ERROR"
+        assert "InternalServerError" in r["message"]
 
     @pytest.mark.asyncio
     async def test_timeout_exception(self):

--- a/sam-powerbi/tests/unit/test_tools.py
+++ b/sam-powerbi/tests/unit/test_tools.py
@@ -1,4 +1,6 @@
 """Unit tests for sam_powerbi.tools."""
+import os
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -146,7 +148,7 @@ class TestGetAuth:
                 tenant_id="tenant-123",
                 client_id="client-456",
                 token_cache_path=_user_cache_path(
-                    "/tmp/samv2/powerbi_msal_cache.json", "user-1"
+                    os.path.expanduser("~/.cache/samv2/powerbi_msal_cache.json"), "user-1"
                 ),
             )
 

--- a/sam-powerbi/tests/unit/test_tools.py
+++ b/sam-powerbi/tests/unit/test_tools.py
@@ -424,6 +424,40 @@ class TestAuthFlow:
         assert r["error_code"] == "AUTH_REQUIRED"
 
     @pytest.mark.asyncio
+    async def test_401_retry_triggers_new_device_flow_carries_error_info(self):
+        """Regression: the reason for the original 401 (e.g. GroupNotAccessible)
+        must survive into the AUTH_REQUIRED response, not just server logs —
+        otherwise the LLM/user only ever sees "sign in again" with no clue
+        that re-authenticating alone won't fix a permissions/access problem.
+        """
+        pending = PowerBIAuthPending(
+            verification_uri="https://aka.ms/devicelogin",
+            user_code="XYZ",
+            expires_in=900,
+            message="Sign in",
+        )
+        resp_401 = _mock_http(
+            401, headers={"X-PowerBI-Error-Info": "GroupNotAccessible"}
+        )
+
+        with patch("sam_powerbi.tools._get_auth") as m:
+            auth = MagicMock()
+            auth.get_token_or_start_device_flow.side_effect = ["token", pending]
+            m.return_value = auth
+
+            with patch("httpx.AsyncClient") as mock_cls:
+                inst = AsyncMock()
+                inst.post.return_value = resp_401
+                mock_cls.return_value.__aenter__ = AsyncMock(return_value=inst)
+                mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+                r = await execute_powerbi_query("EVALUATE 'T'", tool_config=MINIMAL_CFG)
+
+        assert r["error_code"] == "AUTH_REQUIRED"
+        assert "GroupNotAccessible" in r["message"]
+        assert r["powerbi_error_info"] == "GroupNotAccessible"
+
+    @pytest.mark.asyncio
     async def test_401_retry_triggers_auth_error(self):
         resp_401 = _mock_http(401)
 
@@ -468,6 +502,7 @@ class TestAuthFlow:
 
         assert r["error_code"] == "AUTH_ERROR"
         assert "TokenExpired" in r["message"]
+        assert r["powerbi_error_info"] == "TokenExpired"
         auth.force_reauth.assert_called_once()
 
     @pytest.mark.asyncio

--- a/sam-powerbi/tests/unit/test_tools.py
+++ b/sam-powerbi/tests/unit/test_tools.py
@@ -765,18 +765,21 @@ class TestHTTPResponseHandling:
         assert "(truncated)" in r["message"]
 
     @pytest.mark.asyncio
-    async def test_custom_rest_timeout_passed_to_httpx(self):
+    async def test_custom_rest_timeout_passed_to_fail_after(self):
         cfg = {**MINIMAL_CFG, "rest_timeout_seconds": "7"}
         resp = _mock_http(200, json_data={"results": []})
 
-        with patch("httpx.AsyncClient") as mock_cls:
+        with patch("httpx.AsyncClient") as mock_cls, patch(
+            "sam_powerbi.tools.anyio.fail_after"
+        ) as mock_fail_after:
             inst = AsyncMock()
             inst.post.return_value = resp
             mock_cls.return_value.__aenter__ = AsyncMock(return_value=inst)
             mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
             await execute_powerbi_query("EVALUATE 'T'", tool_config=cfg)
 
-        mock_cls.assert_called_with(timeout=7.0)
+        mock_cls.assert_called_with(timeout=None)
+        mock_fail_after.assert_called_with(7.0)
 
     @pytest.mark.asyncio
     async def test_unexpected_exception(self):

--- a/sam-powerbi/tests/unit/test_tools.py
+++ b/sam-powerbi/tests/unit/test_tools.py
@@ -222,7 +222,7 @@ class TestUserIdThreading:
 
     def _tool_context(self, user_id):
         ctx = MagicMock()
-        ctx.invocation_context.user_id = user_id
+        ctx.session.user_id = user_id
         return ctx
 
     @pytest.mark.asyncio

--- a/sam-powerbi/tests/unit/test_tools.py
+++ b/sam-powerbi/tests/unit/test_tools.py
@@ -7,6 +7,7 @@ import httpx
 from sam_powerbi.tools import (
     _require,
     _get_auth,
+    _user_cache_path,
     _format_results_markdown,
     execute_powerbi_query,
     _auth_cache,
@@ -140,18 +141,20 @@ class TestGetAuth:
     def test_creates_powerbi_auth_with_correct_args(self):
         with patch("sam_powerbi.tools.PowerBIAuth") as mock_cls:
             mock_cls.return_value = MagicMock()
-            _get_auth(MINIMAL_CFG)
+            _get_auth(MINIMAL_CFG, "user-1")
             mock_cls.assert_called_once_with(
                 tenant_id="tenant-123",
                 client_id="client-456",
-                token_cache_path="/tmp/samv2/powerbi_msal_cache.json",
+                token_cache_path=_user_cache_path(
+                    "/tmp/samv2/powerbi_msal_cache.json", "user-1"
+                ),
             )
 
     def test_caches_instance_for_same_key(self):
         with patch("sam_powerbi.tools.PowerBIAuth") as mock_cls:
             mock_cls.return_value = MagicMock()
-            r1 = _get_auth(MINIMAL_CFG)
-            r2 = _get_auth(MINIMAL_CFG)
+            r1 = _get_auth(MINIMAL_CFG, "user-1")
+            r2 = _get_auth(MINIMAL_CFG, "user-1")
             assert r1 is r2
             mock_cls.assert_called_once()
 
@@ -159,20 +162,32 @@ class TestGetAuth:
         with patch("sam_powerbi.tools.PowerBIAuth") as mock_cls:
             auth_a, auth_b = MagicMock(), MagicMock()
             mock_cls.side_effect = [auth_a, auth_b]
-            r1 = _get_auth({**MINIMAL_CFG, "tenant_id": "tenant-A"})
-            r2 = _get_auth({**MINIMAL_CFG, "tenant_id": "tenant-B"})
+            r1 = _get_auth({**MINIMAL_CFG, "tenant_id": "tenant-A"}, "user-1")
+            r2 = _get_auth({**MINIMAL_CFG, "tenant_id": "tenant-B"}, "user-1")
             assert r1 is auth_a
             assert r2 is auth_b
+
+    def test_different_users_get_different_instances(self):
+        with patch("sam_powerbi.tools.PowerBIAuth") as mock_cls:
+            auth_a, auth_b = MagicMock(), MagicMock()
+            mock_cls.side_effect = [auth_a, auth_b]
+            r1 = _get_auth(MINIMAL_CFG, "user-1")
+            r2 = _get_auth(MINIMAL_CFG, "user-2")
+            assert r1 is auth_a
+            assert r2 is auth_b
+            assert mock_cls.call_args_list[0].kwargs["token_cache_path"] != (
+                mock_cls.call_args_list[1].kwargs["token_cache_path"]
+            )
 
     def test_uses_custom_cache_path(self):
         cfg = {**MINIMAL_CFG, "token_cache_path": "/custom/path.json"}
         with patch("sam_powerbi.tools.PowerBIAuth") as mock_cls:
             mock_cls.return_value = MagicMock()
-            _get_auth(cfg)
+            _get_auth(cfg, "user-1")
             mock_cls.assert_called_once_with(
                 tenant_id="tenant-123",
                 client_id="client-456",
-                token_cache_path="/custom/path.json",
+                token_cache_path=_user_cache_path("/custom/path.json", "user-1"),
             )
 
 
@@ -190,6 +205,70 @@ class TestConfigValidation:
     async def test_none_tool_config_treated_as_empty(self):
         r = await execute_powerbi_query("EVALUATE ROW(\"x\", 1)", tool_config=None)
         assert r["error_code"] == "CONFIG_ERROR"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# execute_powerbi_query — per-user identity threading
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestUserIdThreading:
+    @pytest.fixture(autouse=True)
+    def mock_auth(self):
+        with patch("sam_powerbi.tools._get_auth") as m:
+            auth = MagicMock()
+            auth.get_token_or_start_device_flow.return_value = "fake-token"
+            m.return_value = auth
+            yield m
+
+    def _tool_context(self, user_id):
+        ctx = MagicMock()
+        ctx.invocation_context.user_id = user_id
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_passes_tool_context_user_id_to_get_auth(self, mock_auth):
+        resp = _mock_http(200, json_data={"results": []})
+        with patch("httpx.AsyncClient") as mock_cls:
+            inst = AsyncMock()
+            inst.post.return_value = resp
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=inst)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            await execute_powerbi_query(
+                "EVALUATE 'Table'",
+                tool_context=self._tool_context("slack:T1:U123"),
+                tool_config=MINIMAL_CFG,
+            )
+        mock_auth.assert_called_once_with(MINIMAL_CFG, "slack:T1:U123")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_anonymous_without_tool_context(self, mock_auth):
+        resp = _mock_http(200, json_data={"results": []})
+        with patch("httpx.AsyncClient") as mock_cls:
+            inst = AsyncMock()
+            inst.post.return_value = resp
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=inst)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            await execute_powerbi_query(
+                "EVALUATE 'Table'", tool_config=MINIMAL_CFG
+            )
+        mock_auth.assert_called_once_with(MINIMAL_CFG, "anonymous")
+
+
+class TestUserCachePath:
+    def test_same_user_same_path(self):
+        p1 = _user_cache_path("/tmp/samv2/powerbi_msal_cache.json", "user-1")
+        p2 = _user_cache_path("/tmp/samv2/powerbi_msal_cache.json", "user-1")
+        assert p1 == p2
+
+    def test_different_users_different_paths(self):
+        p1 = _user_cache_path("/tmp/samv2/powerbi_msal_cache.json", "user-1")
+        p2 = _user_cache_path("/tmp/samv2/powerbi_msal_cache.json", "user-2")
+        assert p1 != p2
+
+    def test_preserves_extension_and_base(self):
+        p = _user_cache_path("/tmp/samv2/powerbi_msal_cache.json", "user-1")
+        assert p.startswith("/tmp/samv2/powerbi_msal_cache.")
+        assert p.endswith(".json")
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/sam-powerbi/tests/unit/test_tools.py
+++ b/sam-powerbi/tests/unit/test_tools.py
@@ -253,6 +253,22 @@ class TestUserIdThreading:
             )
         mock_auth.assert_called_once_with(MINIMAL_CFG, "anonymous")
 
+    @pytest.mark.asyncio
+    async def test_logs_warning_without_tool_context(self, mock_auth, caplog):
+        resp = _mock_http(200, json_data={"results": []})
+        with patch("httpx.AsyncClient") as mock_cls:
+            inst = AsyncMock()
+            inst.post.return_value = resp
+            mock_cls.return_value.__aenter__ = AsyncMock(return_value=inst)
+            mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            with caplog.at_level("WARNING", logger="sam_powerbi.tools"):
+                await execute_powerbi_query(
+                    "EVALUATE 'Table'", tool_config=MINIMAL_CFG
+                )
+        assert any(
+            "No tool_context" in record.message for record in caplog.records
+        )
+
 
 class TestUserCachePath:
     def test_same_user_same_path(self):


### PR DESCRIPTION
### What is the purpose of this change?

    The powerbi tool needs a token based on the user that uses it. It did not store that token on a per user base. Every user uses the same token once successfully logged in

### How was this change implemented?

    This fix only touches the sam-powerbi tool and it now stores the token based on the user_id, 
    it also surfaces the X-PowerBI-Error-Info header in the log in case of a log error

### How was this change tested?

Unittests were added to check if tokens are stored on a user_id base. Also tests for log warning on anonymous access

### Is there anything the reviewers should focus on/be aware of?

user_id flows from each gateway's authenticate_and_enrich_user() → user_identity["id"] → session_service.create_session(user_id=...) → InvocationContext.user_id. So it's exactly what I'd use in the fix, but its reliability as a true per-human identifier depends entirely on gateway config, not on ADK:

Gateway	Per-human by default?	Fallback when not
Slack	✅ Yes — slack:{team_id}:{slack_user_id} from the event payload	—
REST	Only if auth is enforced (JWT/OAuth claim)	force_user_identity (dev override) or default_user_identity — both shared across all callers
Webhook	Only with basic auth (username) or per-token auth (token_user:{token_name} — shared by everyone using that token)	webhook_anonymous_user — fully generic/shared
Event Mesh	Only if user_identity_expression correctly extracts a real per-user claim from the broker message	default_user_identity — shared