### PR TITLE
chore: onboard FOSSA SCA scanning (DATAGO-142436)

### DIFF
--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -1,0 +1,8 @@
+{
+  "sca_scanning": {
+    "fossa": {
+      "policy": { "mode": "REPORT" },
+      "vulnerability": { "mode": "REPORT" }
+    }
+  }
+}

--- a/.github/workflows/sca-scan-and-guard.yml
+++ b/.github/workflows/sca-scan-and-guard.yml
@@ -1,0 +1,100 @@
+name: SCA Scan on merge to main
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  id-token: write
+  packages: read
+  actions: read
+  statuses: write
+  checks: write
+  pull-requests: write
+
+jobs:
+  sca_scan:
+    strategy:
+      matrix:
+        include:
+          - { path: ., name: solace-agent-mesh-core-plugins }
+          - { path: sam-bedrock-agent, name: sam-bedrock-agent }
+          - { path: sam-event-mesh-agent, name: sam-event-mesh-agent }
+          - { path: sam-event-mesh-gateway, name: sam-event-mesh-gateway }
+          - { path: sam-event-mesh-identity-provider, name: sam-event-mesh-identity-provider }
+          - { path: sam-event-mesh-tool, name: sam-event-mesh-tool }
+          - { path: sam-geo-information, name: sam-geo-information }
+          - { path: sam-mcp-server-gateway-adapter, name: sam-mcp-server-gateway-adapter }
+          - { path: sam-mermaid, name: sam-mermaid }
+          - { path: sam-mongodb, name: sam-mongodb }
+          - { path: sam-nuclia-tool, name: sam-nuclia-tool }
+          - { path: sam-powerbi, name: sam-powerbi }
+          - { path: sam-rag, name: sam-rag }
+          - { path: sam-rest-gateway, name: sam-rest-gateway }
+          - { path: sam-ruleset-lookup-tool, name: sam-ruleset-lookup-tool }
+          - { path: sam-slack, name: sam-slack }
+          - { path: sam-slack-gateway-adapter, name: sam-slack-gateway-adapter }
+          - { path: sam-sql-database, name: sam-sql-database }
+          - { path: sam-sql-database-tool, name: sam-sql-database-tool }
+          - { path: sam-webhook-gateway, name: sam-webhook-gateway }
+    uses: SolaceDev/solace-public-workflows/.github/workflows/sca-scan-and-guard.yaml@main
+    with:
+      additional_scan_params: |
+        fossa.only_path=${{ matrix.path }}
+    secrets:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+
+  update_manifest:
+    needs: sca_scan
+    if: needs.sca_scan.result == 'success' && github.ref_name == github.event.repository.default_branch
+    strategy:
+      matrix:
+        include:
+          - { path: ., name: solace-agent-mesh-core-plugins }
+          - { path: sam-bedrock-agent, name: sam-bedrock-agent }
+          - { path: sam-event-mesh-agent, name: sam-event-mesh-agent }
+          - { path: sam-event-mesh-gateway, name: sam-event-mesh-gateway }
+          - { path: sam-event-mesh-identity-provider, name: sam-event-mesh-identity-provider }
+          - { path: sam-event-mesh-tool, name: sam-event-mesh-tool }
+          - { path: sam-geo-information, name: sam-geo-information }
+          - { path: sam-mcp-server-gateway-adapter, name: sam-mcp-server-gateway-adapter }
+          - { path: sam-mermaid, name: sam-mermaid }
+          - { path: sam-mongodb, name: sam-mongodb }
+          - { path: sam-nuclia-tool, name: sam-nuclia-tool }
+          - { path: sam-powerbi, name: sam-powerbi }
+          - { path: sam-rag, name: sam-rag }
+          - { path: sam-rest-gateway, name: sam-rest-gateway }
+          - { path: sam-ruleset-lookup-tool, name: sam-ruleset-lookup-tool }
+          - { path: sam-slack, name: sam-slack }
+          - { path: sam-slack-gateway-adapter, name: sam-slack-gateway-adapter }
+          - { path: sam-sql-database, name: sam-sql-database }
+          - { path: sam-sql-database-tool, name: sam-sql-database-tool }
+          - { path: sam-webhook-gateway, name: sam-webhook-gateway }
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: arn:aws:iam::868978040651:role/github-solace-cloud-manifest-rw
+          aws-region: us-east-1
+
+      - name: Update solace-cloud-manifest
+        uses: SolaceDev/solace-public-workflows/.github/actions/cicd-helper@main
+        with:
+          rc_step: add_item_from_json_to_dynamodb_table
+          ddb_table_name: solace-cloud-manifest
+          ddb_partition_key: squad
+          ddb_sort_key: repository
+          ddb_item_to_be_added: |
+            {
+              "squad": "temp",
+              "repository": "${{ matrix.name }}",
+              "dev": {
+                "sha": "${{ github.sha }}",
+                "version": "${{ github.ref_name }}"
+              }
+            }

--- a/sam-event-mesh-identity-provider/.fossa.yml
+++ b/sam-event-mesh-identity-provider/.fossa.yml
@@ -1,0 +1,21 @@
+version: 3
+project:
+  locator: SolaceLabs_sam-event-mesh-identity-provider
+  id: SolaceLabs_sam-event-mesh-identity-provider
+  name: sam-event-mesh-identity-provider
+  teams: []
+  labels:
+    - python
+vendoredDependencies:
+  forceRescans: false
+  scanMethod: CLILicenseScan
+  licenseScanPathFilters:
+    exclude:
+      - "./.git"
+      - "./.github"
+paths:
+  exclude:
+    - ./.git
+    - ./.github
+telemetry:
+  scope: full

--- a/sam-mermaid/.fossa.yml
+++ b/sam-mermaid/.fossa.yml
@@ -1,0 +1,21 @@
+version: 3
+project:
+  locator: SolaceLabs_sam-mermaid
+  id: SolaceLabs_sam-mermaid
+  name: sam-mermaid
+  teams: []
+  labels:
+    - python
+vendoredDependencies:
+  forceRescans: false
+  scanMethod: CLILicenseScan
+  licenseScanPathFilters:
+    exclude:
+      - "./.git"
+      - "./.github"
+paths:
+  exclude:
+    - ./.git
+    - ./.github
+telemetry:
+  scope: full


### PR DESCRIPTION
## Summary
- Add `.fossa.yml` for `sam-event-mesh-identity-provider` and `sam-mermaid` (the 2 submodules missing configs)
- Add `.github/workflow-config.json` (REPORT mode for licensing + vulnerability)
- Add matrix `sca-scan-and-guard.yml` workflow — root + all 19 submodules, each scanned via `fossa.only_path`

## Test plan
- [ ] Merge to main and verify all 20 matrix scan jobs pass in GitHub Actions
- [ ] Confirm each submodule appears in FOSSA under its own locator

🤖 Generated with [Claude Code](https://claude.com/claude-code)